### PR TITLE
Gitignore and requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,41 @@
+## Windows
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+## macOS
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+
+
+## Python
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
 FROM gw000/keras:2.0.6-py3-tf-cpu
 
-# install dependencies from debian packages
 RUN apt-get update -qq \
  && apt-get install --no-install-recommends -y \
     python-pip \
     python-dev
 
+COPY requirements.txt .
+
 # install dependencies from python packages
 RUN pip install --upgrade setuptools
 
-RUN pip install --upgrade keras
+RUN pip --no-cache-dir install -r ./requirements.txt
 
 # 'os.scandir()' does not work in utils.py. replace with 'scandir()', and modify 'import os' to 'from scandir import scandir'
 RUN pip --no-cache-dir install \
-    tensorflow \
-    opencv-python \
     pathlib \
     scandir \
-    h5py

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,3 @@ RUN pip --no-cache-dir install \
     scikit-image \
     # boost \
     dlib
->>>>>>> 0451905dc23725413a7515fd6174dbba32aa3fc1

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,3 @@ COPY requirements.txt .
 RUN pip install --upgrade setuptools
 
 RUN pip --no-cache-dir install -r ./requirements.txt
-
-# 'os.scandir()' does not work in utils.py. replace with 'scandir()', and modify 'import os' to 'from scandir import scandir'
-RUN pip --no-cache-dir install \
-    pathlib \
-    scandir \

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,6 @@
+pathlib==1.0.1
+scandir==1.6
+h5py==2.7.1
+Keras==2.1.2
+opencv-python==3.3.0.10
+tensorflow-gpu==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pathlib==1.0.1
+scandir==1.6
+h5py==2.7.1
+Keras==2.1.2
+opencv-python==3.3.0.10
+tensorflow==1.4.1


### PR DESCRIPTION
Small quality of life improvements like pip requirements files. Specific versions listed are the ones that I used for testing, but improvements and suggestions are most welcome.

- Added a basic `.gitignore` with a few windows/mac and python presets. (perhaps add data/model directories too so people don't accidentally commit those)
- Added `requirements.txt` and `requirements-gpu.txt`