### PR TITLE
Implemented options to change the input directories for the pictures.

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,72 +1,86 @@
 import cv2
 import numpy
+import sys
 
-from lib.utils import get_image_paths, load_images, stack_images
-from lib.training_data import get_training_data
+from utils import get_image_paths, load_images, stack_images
+from training_data import get_training_data
 
-from lib.model import autoencoder_A
-from lib.model import autoencoder_B
-from lib.model import encoder, decoder_A, decoder_B
+from model import autoencoder_A
+from model import autoencoder_B
+from model import encoder, decoder_A, decoder_B
+from getopt import getopt
+
 
 try:
-    encoder.load_weights('models/encoder.h5')
-    decoder_A.load_weights('models/decoder_A.h5')
-    decoder_B.load_weights('models/decoder_B.h5')
+    opts, args = getopt(sys.argv[1:], "a:b:", ["image-a=", "image-b="])
+except GetoptError as err:
+    print(err)
+    sys.exit(2)
+for option, value in opts:
+    if option in ("-a", "--image-a"):
+        imageAFolder = value
+    elif option in ("-b", "--image-b"):
+        imageBFolder = value
+    else:
+        assert False, "Unhandled option"
+
+print("Image A path is {}".format(imageAFolder))
+print("Image B path is {}".format(imageBFolder))
+
+try:
+    encoder.load_weights( "models/encoder.h5"   )
+    decoder_A.load_weights( "models/decoder_A.h5" )
+    decoder_B.load_weights( "models/decoder_B.h5" )
 except:
     pass
 
-
 def save_model_weights():
-    encoder.save_weights('models/encoder.h5')
-    decoder_A.save_weights('models/decoder_A.h5')
-    decoder_B.save_weights('models/decoder_B.h5')
-    print('save model weights')
+    encoder.save_weights( "models/encoder.h5"   )
+    decoder_A.save_weights( "models/decoder_A.h5" )
+    decoder_B.save_weights( "models/decoder_B.h5" )
+    print( "save model weights" )
 
+images_A = get_image_paths( imageAFolder )
+images_B = get_image_paths( imageBFolder )
+images_A = load_images( images_A ) / 255.0
+images_B = load_images( images_B ) / 255.0
 
-def show_sample(test_A, test_B):
-    figure_A = numpy.stack([
-        test_A,
-        autoencoder_A.predict(test_A),
-        autoencoder_B.predict(test_A),
-        ], axis=1)
-    figure_B = numpy.stack([
-        test_B,
-        autoencoder_B.predict(test_B),
-        autoencoder_A.predict(test_B),
-        ], axis=1)
+images_A += images_B.mean( axis=(0,1,2) ) - images_A.mean( axis=(0,1,2) )
 
-    figure = numpy.concatenate([figure_A, figure_B], axis=0)
-    figure = figure.reshape((4, 7) + figure.shape[1:])
-    figure = stack_images(figure)
-
-    figure = numpy.clip(figure * 255, 0, 255).astype('uint8')
-
-    cv2.imwrite('_sample.jpg', figure)
-
-
-images_A = get_image_paths('data/trump')
-images_B = get_image_paths('data/cage')
-images_A = load_images(images_A) / 255.0
-images_B = load_images(images_B) / 255.0
-
-images_A += images_B.mean(axis=(0, 1, 2)) - images_A.mean(axis=(0, 1, 2))
-
-print('press "q" to stop training and save model')
-
-BATCH_SIZE = 64
+print( "press 'q' to stop training and save model" )
 
 for epoch in range(1000000):
-    warped_A, target_A = get_training_data(images_A, BATCH_SIZE)
-    warped_B, target_B = get_training_data(images_B, BATCH_SIZE)
+    batch_size = 64
+    warped_A, target_A = get_training_data( images_A, batch_size )
+    warped_B, target_B = get_training_data( images_B, batch_size )
 
-    loss_A = autoencoder_A.train_on_batch(warped_A, target_A)
-    loss_B = autoencoder_B.train_on_batch(warped_B, target_B)
-    print(loss_A, loss_B)
+    loss_A = autoencoder_A.train_on_batch( warped_A, target_A )
+    loss_B = autoencoder_B.train_on_batch( warped_B, target_B )
+    print( loss_A, loss_B )
 
     if epoch % 100 == 0:
         save_model_weights()
-        show_sample(target_A[0:14], target_B[0:14])
+        test_A = target_A[0:14]
+        test_B = target_B[0:14]
 
+    figure_A = numpy.stack([
+        test_A,
+        autoencoder_A.predict( test_A ),
+        autoencoder_B.predict( test_A ),
+        ], axis=1 )
+    figure_B = numpy.stack([
+        test_B,
+        autoencoder_B.predict( test_B ),
+        autoencoder_A.predict( test_B ),
+        ], axis=1 )
+
+    figure = numpy.concatenate( [ figure_A, figure_B ], axis=0 )
+    figure = figure.reshape( (4,7) + figure.shape[1:] )
+    figure = stack_images( figure )
+
+    figure = numpy.clip( figure * 255, 0, 255 ).astype('uint8')
+
+    cv2.imshow( "", figure )
     key = cv2.waitKey(1)
     if key == ord('q'):
         save_model_weights()


### PR DESCRIPTION
I changed the train.py script to be able to change the source image folder. So now it is not hardcoded you can use `python train.py-a imgA/ -b imgB/` or `python train.py--image-a=imgA/ --image-b=imgB/`

I don't know if you accept this kind of PR but I find it useful.