### PR TITLE
Print out which image caused error

### DIFF
--- a/lib/training_data.py
+++ b/lib/training_data.py
@@ -25,7 +25,7 @@ def read_image(fn, random_transform_args=random_transform_args):
     try:
         image = cv2.imread(fn) / 255.0
     except TypeError:
-        raise Exception("Error while reading image",fn)
+        raise Exception("Error while reading image", fn)
     image = cv2.resize(image, (256,256))
     image = random_transform( image, **random_transform_args )
     warped_img, target_img = random_warp( image )

--- a/lib/training_data.py
+++ b/lib/training_data.py
@@ -22,13 +22,16 @@ random_transform_args = {
 #     'random_flip': 0.5,
 #     }
 def read_image(fn, random_transform_args=random_transform_args):
-    image = cv2.imread(fn) / 255.0
+    try:
+        image = cv2.imread(fn) / 255.0
+    except TypeError:
+        raise Exception("Error while reading image",fn)
     image = cv2.resize(image, (256,256))
     image = random_transform( image, **random_transform_args )
     warped_img, target_img = random_warp( image )
     
     return warped_img, target_img
-
+ 
 # A generator function that yields epoch, batchsize of warped_img and batchsize of target_img
 def minibatch(data, batchsize):
     length = len(data)

--- a/lib/training_data.py
+++ b/lib/training_data.py
@@ -31,7 +31,7 @@ def read_image(fn, random_transform_args=random_transform_args):
     warped_img, target_img = random_warp( image )
     
     return warped_img, target_img
- 
+
 # A generator function that yields epoch, batchsize of warped_img and batchsize of target_img
 def minibatch(data, batchsize):
     length = len(data)


### PR DESCRIPTION
Exception message on encountering a corrupted image used to be:

```
libpng error: IDAT: CRC error.04081, loss_B: 0.05761
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/home/leijurv/Documents/faceswap/lib/utils.py", line 42, in run
    for item in self.generator:
  File "/home/leijurv/Documents/faceswap/lib/training_data.py", line 43, in minibatch
    rtn = numpy.float32([read_image(data[j]) for j in range(i,i+size)])
  File "/home/leijurv/Documents/faceswap/lib/training_data.py", line 43, in <listcomp>
    rtn = numpy.float32([read_image(data[j]) for j in range(i,i+size)])
  File "/home/leijurv/Documents/faceswap/lib/training_data.py", line 25, in read_image
    image = cv2.imread(fn) / 255.0
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

Now, it prints out which image specifically caused the error:

```
libpng error: IDAT: CRC error.03255, loss_B: 0.04847
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/home/leijurv/Documents/faceswap/lib/training_data.py", line 26, in read_image
    image = cv2.imread(fn) / 255.0
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/home/leijurv/Documents/faceswap/lib/utils.py", line 42, in run
    for item in self.generator:
  File "/home/leijurv/Documents/faceswap/lib/training_data.py", line 46, in minibatch
    rtn = numpy.float32([read_image(data[j]) for j in range(i,i+size)])
  File "/home/leijurv/Documents/faceswap/lib/training_data.py", line 46, in <listcomp>
    rtn = numpy.float32([read_image(data[j]) for j in range(i,i+size)])
  File "/home/leijurv/Documents/faceswap/lib/training_data.py", line 28, in read_image
    raise Exception("Error while reading image",fn)
Exception: ('Error while reading image', '/home/leijurv/faceswap/data/B/batch5_3970.png')
```