### PR TITLE
color match A and B set images + performance improvement

### DIFF
--- a/lib/ModelAE.py
+++ b/lib/ModelAE.py
@@ -51,12 +51,10 @@ class TrainerAE():
         self.model = model
 
         generator = TrainingDataGenerator(self.random_transform_args, 160)
-        self.images_A = generator.minibatchAB(fn_A, self.batch_size)
-        self.images_B = generator.minibatchAB(fn_B, self.batch_size)
+        self.images = generator.minibatchAB(fn_A, fn_B, self.batch_size)
 
     def train_one_step(self, iter, viewer):
-        epoch, warped_A, target_A = next(self.images_A)
-        epoch, warped_B, target_B = next(self.images_B)
+        epoch, warped_A, target_A, warped_B, target_B = next(self.images)
 
         loss_A = self.model.autoencoder_A.train_on_batch(warped_A, target_A)
         loss_B = self.model.autoencoder_B.train_on_batch(warped_B, target_B)

--- a/lib/training_data.py
+++ b/lib/training_data.py
@@ -42,6 +42,7 @@ class TrainingDataGenerator():
         
         epoch = index_A = index_B = 0
         shuffle(images_A)
+        shuffle(images_B)
         
         while True:
             overflow=False


### PR DESCRIPTION
improve performance by pre-loading images before iteration.

i noticed FakeApp does this better by matching the colors between the sets so i added that back in
also avoiding cv2.readim on each iteration is a much better idea than doing that repeatedly
 (HDD's are slow)
i'm seeing a nice performance improvement from this as-well