### PR TITLE
keeping aligner next to Extract, under plugins and not under lib

### DIFF
--- a/plugins/Convert_Masked.py
+++ b/plugins/Convert_Masked.py
@@ -3,7 +3,7 @@
 import cv2
 import numpy
 
-from lib.aligner import get_align_mat
+from .Extract_Align.aligner import get_align_mat
 
 class Convert():
     def __init__(self, encoder, blur_size=2, seamless_clone=False, mask_type="facehullandrect", erosion_kernel_size=None, **kwargs):


### PR DESCRIPTION
Masked was not working on oatsss branch for original model because files were moved. This doesn't apply to current master