### PR TITLE
fix #233, #237, + working with any batch size

### DIFF
--- a/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
+++ b/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
@@ -3,30 +3,24 @@ import numpy as np
 import os
 import cv2
 import dlib
-
-
 import keras
 from keras import backend as K
 
-dlib_cnn_face_detector = None
-dlib_face_detector = None
+dlib_detectors = []
 keras_model = None
+is_initialized = False
 
 @atexit.register
 def onExit():
-    global dlib_cnn_face_detector
-    global dlib_face_detector
+    global dlib_detectors
     global keras_model
     
     if keras_model is not None:
         del keras_model
         K.clear_session()
         
-    if dlib_cnn_face_detector is not None:
-        del dlib_cnn_face_detector
-    
-    if dlib_face_detector is not None:
-        del dlib_face_detector
+    for detector in dlib_detectors:
+        del detector
         
 class TorchBatchNorm2D(keras.engine.topology.Layer):
     def __init__(self, axis=-1, momentum=0.99, epsilon=1e-3, **kwargs):
@@ -111,55 +105,59 @@ def get_pts_from_predict(a, center, scale):
     c += 0.5
     return [ transform (c[i], center, scale, a.shape[2]) for i in range(a.shape[0]) ]
 
-def extract(input_image, use_cnn_face_detector=True, all_faces=True, max_res_side=1112 ):
-#max_res_side=1112 for 3GB VRAM Windows 10 users.
+def initialize(scale_to=2048):
+    global dlib_detectors
+    global keras_model
+    global is_initialized
+    if not is_initialized:       
+        
+        dlib_cnn_face_detector_path = os.path.join(os.path.dirname(__file__), "mmod_human_face_detector.dat")
+        if not os.path.exists(dlib_cnn_face_detector_path):
+            raise Exception ("Error: Unable to find %s, reinstall the lib !" % (dlib_cnn_face_detector_path) )
+        else:
+            dlib_cnn_face_detector = dlib.cnn_face_detection_model_v1(dlib_cnn_face_detector_path)            
+            #DLIB and TF competiting for VRAM, so dlib must do first allocation to prevent OOM error 
+            dlib_cnn_face_detector ( np.zeros ( (scale_to, scale_to, 3), dtype=np.uint8), 0 ) 
+            dlib_detectors.append(dlib_cnn_face_detector)
+    
+        dlib_face_detector = dlib.get_frontal_face_detector()
+        dlib_face_detector ( np.zeros ( (scale_to, scale_to, 3), dtype=np.uint8), 0 )
+        dlib_detectors.append(dlib_face_detector)        
+        
+        keras_model_path = os.path.join( os.path.dirname(__file__) , "2DFAN-4.h5" )
+        if not os.path.exists(keras_model_path):
+            print ("Error: Unable to find %s, reinstall the lib !" % (keras_model_path) )
+        else:
+            print ("Info: initializing keras model...")
+            keras_model = keras.models.load_model (keras_model_path, custom_objects={'TorchBatchNorm2D': TorchBatchNorm2D} ) 
+            
+        is_initialized = True
 
-    global dlib_cnn_face_detector
-    global dlib_face_detector
+#scale_to=2048 with dlib upsamples=0 for 3GB VRAM Windows 10 users        
+def extract(input_image, use_cnn_face_detector=True, all_faces=True, scale_to=2048 ):
+    initialize(scale_to)
+    global dlib_detectors
     global keras_model
     
     (h, w, ch) = input_image.shape
 
-    input_scale = 1.0
-    if w > h and w > max_res_side:
-        input_scale = max_res_side / w
-    if h > w and h > max_res_side:
-        input_scale = max_res_side / h
-        
-    if input_scale != 1.0:
-        input_image = cv2.resize (input_image, ( int(w*input_scale), int(h*input_scale) ), interpolation=cv2.INTER_LINEAR)
-
-    #DLIB and TF competiting for VRAM, so dlib must do first allocation to prevent OOM error 
-    if use_cnn_face_detector and dlib_cnn_face_detector is None:
-        dlib_cnn_face_detector_path = os.path.join(os.path.dirname(__file__), "mmod_human_face_detector.dat")
-        if not os.path.exists(dlib_cnn_face_detector_path):
-            print ("Error: Unable to find %s, reinstall the lib !" % (dlib_cnn_face_detector_path) )
-        else:
-            dlib_cnn_face_detector = dlib.cnn_face_detection_model_v1(dlib_cnn_face_detector_path)            
-            dlib_cnn_face_detector ( np.zeros ( (max_res_side, max_res_side, 3), dtype=np.float32), 1 )
-    
-    if dlib_face_detector is None:
-        dlib_face_detector = dlib.get_frontal_face_detector()
-        dlib_face_detector ( np.zeros ( (max_res_side, max_res_side, 3), dtype=np.float32), 1 )
-                
+    input_scale = scale_to / (w if w > h else h)
+    input_image = cv2.resize (input_image, ( int(w*input_scale), int(h*input_scale) ), interpolation=cv2.INTER_LINEAR)
+    input_image_bgr = input_image[:,:,::-1].copy() #cv2 and numpy inputs differs in rgb-bgr order, this affects chance of dlib face detection
+    input_images = [input_image, input_image_bgr]
+ 
+    detected_faces = []
     if use_cnn_face_detector:
-        detected_faces = dlib_cnn_face_detector(input_image, 1)
-        if len(detected_faces) == 0:
-            use_cnn_face_detector = False
-            detected_faces = dlib_face_detector(input_image, 1)
+        for detector, input_image in ((detector, input_image) for detector in dlib_detectors for input_image in input_images):
+            detected_faces = detector(input_image, 0)
             if len(detected_faces) != 0:
-                print ('Info: CNN found no faces, but HOG found !')
+                break
     else:        
-        detected_faces = dlib_face_detector(input_image, 1)
-    
-    if keras_model is None:        
-        model_path = os.path.join( os.path.dirname(__file__) , "2DFAN-4.h5" )
-        if not os.path.exists(model_path):
-            print ("Error: Unable to find %s, reinstall the lib !" % (model_path) )
-        else:
-            print ("Info: initializing keras model...")
-            keras_model = keras.models.load_model (model_path, custom_objects={'TorchBatchNorm2D': TorchBatchNorm2D} ) 
-    
+        for input_image in input_images:
+            detected_faces = dlib_detectors[1](input_image, 0)
+            if len(detected_faces) != 0:
+                break
+
     landmarks = []
     if len(detected_faces) > 0:        
         for i, d in enumerate(detected_faces):

--- a/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
+++ b/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
@@ -160,14 +160,15 @@ def extract(input_image, use_cnn_face_detector=True, all_faces=True, scale_to=20
 
     landmarks = []
     if len(detected_faces) > 0:        
-        for i, d in enumerate(detected_faces):
+        for i, d_rect in enumerate(detected_faces):
             if i > 0 and not all_faces:
                 break
-            
-            d_rect = d.rect if use_cnn_face_detector else d
         
+            if type(d_rect) == dlib.mmod_rectangle:
+                d_rect = d_rect.rect
+            
             left, top, right, bottom = d_rect.left(), d_rect.top(), d_rect.right(), d_rect.bottom()
-            del d
+            del d_rect
     
             center = np.array( [ (left + right) / 2.0, (top + bottom) / 2.0] )
             center[1] -= (bottom - top) * 0.12

--- a/lib/ModelAE.py
+++ b/lib/ModelAE.py
@@ -78,8 +78,14 @@ class TrainerAE():
             self.model.autoencoder_A.predict(test_B),
         ], axis=1)
 
+        if test_A.shape[0] % 2 == 1:
+            figure_A = numpy.concatenate ([figure_A, numpy.expand_dims(figure_A[0],0) ])
+            figure_B = numpy.concatenate ([figure_B, numpy.expand_dims(figure_B[0],0) ])
+        
         figure = numpy.concatenate([figure_A, figure_B], axis=0)
-        figure = figure.reshape((4, 7) + figure.shape[1:])
+        w = 4
+        h = int( figure.shape[0] / w)        
+        figure = figure.reshape((w, h) + figure.shape[1:])        
         figure = stack_images(figure)
-
+        
         return numpy.clip(figure * 255, 0, 255).astype('uint8')


### PR DESCRIPTION
fix #233 - primordial bug when dlib recognizes less faces than FakeApp, reason: rgb-bgr order affects chance of face recognition. Numpy.imread and cv2.imread loads same image in different rgb-bgr order.


fix #237

fix working with any batch size
batch size = 1

![python_2018-03-02_19-01-59](https://user-images.githubusercontent.com/8076202/36906293-f7b2aa22-1e4e-11e8-823d-651625394cd3.png)

2:

![python_2018-03-02_19-02-37](https://user-images.githubusercontent.com/8076202/36906307-02a336e0-1e4f-11e8-897a-61e13a4afaf2.png)

3:

![python_2018-03-02_19-03-18](https://user-images.githubusercontent.com/8076202/36906309-04fd72ca-1e4f-11e8-9d66-24a61d2fd5bd.png)

 etc