### PR TITLE
Allows applying dilation by passing negative erosion kernel values. If value is negative, …

### DIFF
--- a/plugins/Convert_Masked.py
+++ b/plugins/Convert_Masked.py
@@ -8,11 +8,13 @@ from lib.aligner import get_align_mat
 class Convert():
     def __init__(self, encoder, blur_size=2, seamless_clone=False, mask_type="facehullandrect", erosion_kernel_size=None, **kwargs):
         self.encoder = encoder
-
         self.erosion_kernel = None
+        self.erosion_kernel_size = erosion_kernel_size       
         if erosion_kernel_size is not None:
-            self.erosion_kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE,(erosion_kernel_size,erosion_kernel_size))
-
+            if erosion_kernel_size > 0:
+                self.erosion_kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE,(erosion_kernel_size,erosion_kernel_size))
+            elif erosion_kernel_size < 0:
+                self.erosion_kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE,(abs(erosion_kernel_size),abs(erosion_kernel_size)))
         self.blur_size = blur_size
         self.seamless_clone = seamless_clone
         self.mask_type = mask_type.lower() # Choose in 'FaceHullAndRect','FaceHull','Rect'
@@ -86,7 +88,11 @@ class Convert():
 
 
         if self.erosion_kernel is not None:
-            image_mask = cv2.erode(image_mask,self.erosion_kernel,iterations = 1)
+            if self.erosion_kernel_size > 0:
+                image_mask = cv2.erode(image_mask,self.erosion_kernel,iterations = 1)
+            elif self.erosion_kernel_size < 0:
+                dilation_kernel = abs(self.erosion_kernel)
+                image_mask = cv2.dilate(image_mask,dilation_kernel,iterations = 1)
 
         if self.blur_size!=0:
             image_mask = cv2.blur(image_mask,(self.blur_size,self.blur_size))

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -97,7 +97,7 @@ class ConvertImage(DirectoryProcessor):
                             dest="erosion_kernel_size",
                             type=int,
                             default=None,
-                            help="Erosion kernel size. (Masked converter only)")
+                            help="Erosion kernel size. (Masked converter only). If negative, it is interpreted as dilation kernel size")
 
         parser.add_argument('-sm', '--smooth-mask',
                             action="store_true",

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -97,7 +97,8 @@ class ConvertImage(DirectoryProcessor):
                             dest="erosion_kernel_size",
                             type=int,
                             default=None,
-                            help="Erosion kernel size. (Masked converter only). If negative, it is interpreted as dilation kernel size")
+                            help="Erosion kernel size. (Masked converter only). Positive values apply erosion which reduces the edge \ 
+                            of the swapped face. Negative values apply dilation which allows the swapped face to cover more space.")
 
         parser.add_argument('-sm', '--smooth-mask',
                             action="store_true",


### PR DESCRIPTION
…it turns it into a dilation kernel, which allows facehullandrect to cover more space. Can help to cover double eyebrows. Also could be useful with Masked converter for GAN in @oatssss PR.