### PR TITLE
Add multi-GPU support.

### DIFF
--- a/lib/ModelAE.py
+++ b/lib/ModelAE.py
@@ -9,8 +9,9 @@ decoder_AH5 = 'decoder_A.h5'
 decoder_BH5 = 'decoder_B.h5'
 
 class ModelAE:
-    def __init__(self, model_dir):
+    def __init__(self, model_dir, gpus=1):
         self.model_dir = model_dir
+        self.gpus = gpus
 
         self.encoder = self.Encoder()
         self.decoder_A = self.Decoder()
@@ -46,7 +47,8 @@ class TrainerAE():
         'random_flip': 0.4,
     }
 
-    def __init__(self, model, fn_A, fn_B, batch_size=64):
+    def __init__(self, model, fn_A, fn_B, batch_size=64, gpus=1):
+        self.gpus=gpus
         self.batch_size = batch_size
         self.model = model
 

--- a/plugins/Model_LowMem.py
+++ b/plugins/Model_LowMem.py
@@ -9,6 +9,8 @@ from keras.optimizers import Adam
 from lib.ModelAE import ModelAE, TrainerAE
 from lib.PixelShuffler import PixelShuffler
 
+from keras.utils import multi_gpu_model
+
 IMAGE_SHAPE = (64, 64, 3)
 ENCODER_DIM = 512
 
@@ -19,6 +21,10 @@ class Model(ModelAE):
 
         self.autoencoder_A = KerasModel(x, self.decoder_A(self.encoder(x)))
         self.autoencoder_B = KerasModel(x, self.decoder_B(self.encoder(x)))
+
+        if self.gpus > 1:
+            self.autoencoder_A = multi_gpu_model( self.autoencoder_A , self.gpus)
+            self.autoencoder_B = multi_gpu_model( self.autoencoder_B , self.gpus)
 
         self.autoencoder_A.compile(optimizer=optimizer, loss='mean_absolute_error')
         self.autoencoder_B.compile(optimizer=optimizer, loss='mean_absolute_error')

--- a/plugins/Model_Original.py
+++ b/plugins/Model_Original.py
@@ -9,6 +9,8 @@ from keras.optimizers import Adam
 from lib.ModelAE import ModelAE, TrainerAE
 from lib.PixelShuffler import PixelShuffler
 
+from keras.utils import multi_gpu_model
+
 IMAGE_SHAPE = (64, 64, 3)
 ENCODER_DIM = 1024
 
@@ -19,6 +21,10 @@ class Model(ModelAE):
 
         self.autoencoder_A = KerasModel(x, self.decoder_A(self.encoder(x)))
         self.autoencoder_B = KerasModel(x, self.decoder_B(self.encoder(x)))
+
+        if self.gpus > 1:
+            self.autoencoder_A = multi_gpu_model( self.autoencoder_A , self.gpus)
+            self.autoencoder_B = multi_gpu_model( self.autoencoder_B , self.gpus)
 
         self.autoencoder_A.compile(optimizer=optimizer, loss='mean_absolute_error')
         self.autoencoder_B.compile(optimizer=optimizer, loss='mean_absolute_error')

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -88,6 +88,10 @@ class TrainingProcessor(object):
                             type=int,
                             default=1000000,
                             help="Length of training in epochs.")
+        parser.add_argument('-g', '--gpus',
+                            type=int,
+                            default=1,
+                            help="Number of GPUs to use for training")
         parser = self.add_optional_arguments(parser)
         parser.set_defaults(func=self.process_arguments)
 
@@ -134,7 +138,7 @@ class TrainingProcessor(object):
         # this is so that you can enter case insensitive values for trainer
         trainer = self.arguments.trainer
         trainer = "LowMem" if trainer.lower() == "lowmem" else trainer
-        model = PluginLoader.get_model(trainer)(get_folder(self.arguments.model_dir))
+        model = PluginLoader.get_model(trainer)(get_folder(self.arguments.model_dir),self.arguments.gpus)
         model.load(swapped=False)
 
         images_A = get_image_paths(self.arguments.input_A)


### PR DESCRIPTION
Added multi-GPU support through -g --gpu flag.

This has been tested on all 3 models (lowmem, original and GAN).  It works with the default GPUs being 1.  Currently does not use multi GPUs for convert, as that was untested and may cause other issues.  However, models can change the number of GPUs in use without issue.

Save in faceswap is already multi-GPU friendly and does not require any further changes.  One restriction will be against using the built in Keras checkpointing function as it is currently not Multi-GPU safe.  However, other checkpoint modules exist which are supported.