### PR TITLE
Several SQlite3 based optimizations.

### DIFF
--- a/faceswap.py
+++ b/faceswap.py
@@ -10,6 +10,7 @@ from lib.utils import FullHelpArgumentParser
 from scripts.extract import ExtractTrainingData
 from scripts.train import TrainingProcessor
 from scripts.convert import ConvertImage
+from scripts.db import DBManager
 
 def bad_args(args):
     parser.print_help()
@@ -24,6 +25,8 @@ if __name__ == "__main__":
         subparser, "train", "This command trains the model for the two faces A and B.")
     convert = ConvertImage(
         subparser, "convert", "Convert a source image to a new one with the face swapped.")
+    db = DBManager(
+        subparser, "db", "Manage Sqlite3 database.")
     parser.set_defaults(func=bad_args)
     arguments = parser.parse_args()
     arguments.func(arguments)

--- a/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
+++ b/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
@@ -182,5 +182,6 @@ def extract(input_image, use_cnn_face_detector=True, all_faces=True, scale_to=20
             landmarks.append ( ((  int(left/input_scale), int(top/input_scale), int(right/input_scale), int(bottom/input_scale) ),pts_img) )
     else:
         print("Warning: No faces were detected.")
+        return None
         
     return landmarks

--- a/lib/db.py
+++ b/lib/db.py
@@ -1,0 +1,73 @@
+import sqlite3
+import os
+
+table_frames = "CREATE TABLE frames(id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, filename VARCHAR NOT NULL UNIQUE, path TEXT NOT NULL UNIQUE, extracted BOOL DEFAULT false NOT NULL, face_found BOOL DEFAULT false NOT NULL, converted BOOL DEFAULT false NOT NULL);"
+
+def create(filename='faceswap.db'):
+    conn = sqlite3.connect(filename)
+    cur = conn.cursor()
+    cur.execute(table_frames)
+    conn.commit()
+    conn.close()
+
+def close_connection(conn):
+    conn.close()
+
+def open_connection(filename='faceswap.db'):
+    conn = sqlite3.connect(filename)
+    return conn
+
+def record_extraction(conn, filename, face_found):
+    cur = conn.cursor()
+    face_found = str(face_found).lower()
+    try:
+        cur.execute('INSERT INTO frames (filename, path, extracted, face_found) \
+                VALUES (?, ?, "true", ?)', (os.path.basename(filename), filename, face_found))
+    except sqlite3.IntegrityError:
+        cur.execute('UPDATE frames SET \
+                extracted="true", \
+                face_found=? \
+                WHERE filename = ?;', (face_found, filename))
+
+    conn.commit()
+
+def record_conversion(conn, filename, converted):
+    cur = conn.cursor()
+    cur.execute('UPDATE frames SET \
+            converted=? \
+            WHERE filename = ?;', (str(converted).lower(), os.path.basename(filename)))
+    conn.commit()
+
+def get_already_converted(conn):
+    cur = conn.cursor();
+    cur.execute('SELECT filename FROM frames WHERE converted = "true";')
+    return [v[0] for v in cur.fetchall()]
+
+def get_already_extracted(conn):
+    cur = conn.cursor();
+    cur.execute('SELECT filename FROM frames WHERE extracted = "true";')
+    return [v[0] for v in cur.fetchall()]
+
+def get_frames_with_faces(conn):
+    cur = conn.cursor();
+    cur.execute('SELECT filename FROM frames WHERE face_found = "true";')
+    return [v[0] for v in cur.fetchall()]
+
+def flush(conn):
+    cur = conn.cursor();
+    cur.execute("DELETE FROM frames;")
+    conn.commit()
+
+def delete(conn):
+    cur = conn.cursor();
+    cur.execute("DROP TABLE frames;")
+    conn.commit()
+
+def verify(conn):
+    cur = conn.cursor();
+    try:
+        cur.execute("SELECT * FROM frames;")
+    except sqlite3.OperationalError:
+        return False
+    return True
+    

--- a/lib/faces_detect.py
+++ b/lib/faces_detect.py
@@ -2,9 +2,12 @@ from lib import FaceLandmarksExtractor
 
 def detect_faces(frame, model="hog"):
     fd = FaceLandmarksExtractor.extract (frame, True if model == "cnn" else False )
-    for face in fd:
-        x, y, right, bottom, landmarks = face[0][0], face[0][1], face[0][2], face[0][3], face[1]
-        yield DetectedFace(frame[y: bottom, x: right], x, right - x, y, bottom - y, landmarksXY=landmarks)
+    if fd is None:
+        return None
+    else:
+        for face in fd:
+            x, y, right, bottom, landmarks = face[0][0], face[0][1], face[0][2], face[0][3], face[1]
+            yield DetectedFace(frame[y: bottom, x: right], x, right - x, y, bottom - y, landmarksXY=landmarks)
 
 class DetectedFace(object):
     def __init__(self, image=None, x=None, w=None, y=None, h=None, landmarksXY=None):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -13,7 +13,6 @@ def get_folder(path):
     return output_dir
 
 def get_image_paths(directory, exclude=[], debug=False):
-    exclude_names = [basename(Path(x).stem[:-1] + Path(x).suffix) for x in exclude]
     dir_contents = []
 
     if not exists(directory):
@@ -22,7 +21,7 @@ def get_image_paths(directory, exclude=[], debug=False):
     dir_scanned = list(scandir(directory))
     for x in dir_scanned:
         if any([x.name.lower().endswith(ext) for ext in image_extensions]):
-            if x.name in exclude_names:
+            if x.name in exclude:
                 if debug:
                     print("Already processed %s" % x.name)
                 continue

--- a/scripts/db.py
+++ b/scripts/db.py
@@ -1,0 +1,44 @@
+import cv2
+
+from pathlib import Path
+from tqdm import tqdm
+import os
+
+from lib import db
+from lib.cli import DirectoryProcessor
+
+class DBManager(DirectoryProcessor):
+    def create_parser(self, subparser, command, description):
+        self.parser = subparser.add_parser(
+            command,
+            help="Manage Sqlite3 Database.",
+            description=description,
+            )
+
+    def add_optional_arguments(self, parser):
+        parser.add_argument('-f', '--flush',
+                            action='store_true',
+                            dest='db_flush',
+                            default=False,
+                            help="Clears database tables.")
+        
+        parser.add_argument('-d', '--delete',
+                            action="store_true",
+                            dest="db_delete",
+                            default=False,
+                            help="Deletes database schema.")
+        return parser
+
+    def process(self):
+        conn = db.open_connection()
+
+        if self.arguments.db_flush:
+            print("Flushing Database")
+            db.flush(self.conn)
+            print("Done")
+
+        if self.arguments.db_delete:
+            print("Deleting Database")
+            db.delete(self.conn)
+            print("Done")
+


### PR DESCRIPTION
I propose the use of a sqlite3 database to optimize the faceswap in several ways.

The DB stores the frames processed with the Extract script, and marks the ones where a face was found.

This allows two things:
1. To skip already processed frames based on the DB data, instead of comparing input and output directories.
2. To use the Convert script only on those frames where a face was found.

The DB also stores the frames which have already been converted, so It's also possible to skip already converted frames with the --skip-existing argument.

Finally, I think that for future development, having a DB can ease many things: reporting, web-ui, comparison of results with different types of extractors, etc.