### PR TITLE
Fix broken multigpu GAN loading.

### DIFF
--- a/plugins/Model_GAN/Model.py
+++ b/plugins/Model_GAN/Model.py
@@ -116,6 +116,9 @@ class GANModel():
         netGA = Model(x, decoder_A(encoder(x)))
         netGB = Model(x, decoder_B(encoder(x)))
 
+        self.netGA_sm = netGA
+        self.netGB_sm = netGB
+
         try:
             netGA.load_weights(str(self.model_dir / netGAH5))
             netGB.load_weights(str(self.model_dir / netGBH5))
@@ -125,10 +128,8 @@ class GANModel():
             pass
 
         if self.gpus > 1:
-            self.netGA_sm = netGA
-            self.netGB_sm = netGB
-            netGA = multi_gpu_model( netGA , self.gpus)
-            netGB = multi_gpu_model( netGB , self.gpus)
+            netGA = multi_gpu_model( self.netGA_sm , self.gpus)
+            netGB = multi_gpu_model( self.netGB_sm , self.gpus)
 
         return netGA, netGB
 

--- a/plugins/Model_GAN/Model.py
+++ b/plugins/Model_GAN/Model.py
@@ -116,10 +116,6 @@ class GANModel():
         netGA = Model(x, decoder_A(encoder(x)))
         netGB = Model(x, decoder_B(encoder(x)))
 
-        if self.gpus > 1:
-            netGA = multi_gpu_model( netGA , self.gpus)
-            netGB = multi_gpu_model( netGB , self.gpus)
-
         try:
             netGA.load_weights(str(self.model_dir / netGAH5))
             netGB.load_weights(str(self.model_dir / netGBH5))
@@ -127,6 +123,13 @@ class GANModel():
         except:
             print ("Generator weights files not found.")
             pass
+
+        if self.gpus > 1:
+            self.netGA_sm = netGA
+            self.netGB_sm = netGB
+            netGA = multi_gpu_model( netGA , self.gpus)
+            netGB = multi_gpu_model( netGB , self.gpus)
+
         return netGA, netGB
 
     def build_discriminator(self):
@@ -163,8 +166,12 @@ class GANModel():
         return True
 
     def save_weights(self):
-        self.netGA.save_weights(str(self.model_dir / netGAH5))
-        self.netGB.save_weights(str(self.model_dir / netGBH5))
+        if self.gpus > 1:
+            self.netGA_sm.save_weights(str(self.model_dir / netGAH5))
+            self.netGB_sm.save_weights(str(self.model_dir / netGBH5))
+        else:
+            self.netGA.save_weights(str(self.model_dir / netGAH5))
+            self.netGB.save_weights(str(self.model_dir / netGBH5))
         self.netDA.save_weights(str(self.model_dir / netDAH5))
         self.netDB.save_weights(str(self.model_dir / netDBH5))
         print ("Models saved.")


### PR DESCRIPTION
Fix for loading into the multi GPU model when it needs to load/save the original model.

#272 accidentally included a GAN implementation that would not properly load the model causing cumulative corruption over each load/save.  This patch fixes that issue and adds additional safety on saving/loading.

I apologize for the error.  I'd already checked and verified Original, LowMem and IAE but GAN2.0 slipped through due to how it processes the data differently from 1.0 and my rush to add the multi gpu support.  I'll make sure to check better in the future..