### PR TITLE
Adds support for arbitrary image rotations

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -41,6 +41,7 @@ class DirectoryProcessor(object):
     num_faces_detected = 0
     faces_detected = dict()
     verify_output = False
+    rotation_angles = None
 
     def __init__(self, subparser, command, description='default'):
         self.create_parser(subparser, command, description)
@@ -60,8 +61,19 @@ class DirectoryProcessor(object):
             self.serializer = Serializer.get_serializer(self.arguments.serializer or "json")
         print("Using {} serializer".format(self.serializer.ext))
 
+        try:
+            if self.arguments.rotate_images == "on":
+                print("Rotation angle list")
+                print(self.arguments.rotation_angle_list)
+                if self.arguments.rotation_angle_list is not None:
+                    self.rotation_angles = self.arguments.rotation_angle_list
+                else:
+                    self.rotation_angles = range(self.arguments.rotation_angle, 360, self.arguments.rotation_angle)
+        except AttributeError:
+            pass
+
         print('Starting, this may take a while...')
-        
+
         try:
             if self.arguments.skip_existing:
                 self.already_processed = get_image_paths(self.arguments.output_dir)

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -62,13 +62,16 @@ class DirectoryProcessor(object):
         print("Using {} serializer".format(self.serializer.ext))
 
         try:
-            if self.arguments.rotate_images is not None:
-                rotation_angles = [int(angle) for angle in self.arguments.rotate_images.split(",")]
-                if len(rotation_angles) == 1:
-                    rotation_step_size = rotation_angles[0]
-                    self.rotation_angles = range(rotation_step_size, 360, rotation_step_size)
-                elif len(rotation_angles) > 1:
-                    self.rotation_angles = rotation_angles
+            if self.arguments.rotate_images is not None and self.arguments.rotate_images != "off":
+                if self.arguments.rotate_images == "on":
+                    self.rotation_angles = range(90, 360, 90)
+                else:
+                    rotation_angles = [int(angle) for angle in self.arguments.rotate_images.split(",")]
+                    if len(rotation_angles) == 1:
+                        rotation_step_size = rotation_angles[0]
+                        self.rotation_angles = range(rotation_step_size, 360, rotation_step_size)
+                    elif len(rotation_angles) > 1:
+                        self.rotation_angles = rotation_angles
         except AttributeError:
             pass
 

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -63,8 +63,6 @@ class DirectoryProcessor(object):
 
         try:
             if self.arguments.rotate_images == "on":
-                print("Rotation angle list")
-                print(self.arguments.rotation_angle_list)
                 if self.arguments.rotation_angle_list is not None:
                     self.rotation_angles = self.arguments.rotation_angle_list
                 else:

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -62,11 +62,13 @@ class DirectoryProcessor(object):
         print("Using {} serializer".format(self.serializer.ext))
 
         try:
-            if self.arguments.rotate_images == "on":
-                if self.arguments.rotation_angle_list is not None:
-                    self.rotation_angles = self.arguments.rotation_angle_list
-                else:
-                    self.rotation_angles = range(self.arguments.rotation_angle, 360, self.arguments.rotation_angle)
+            if self.arguments.rotate_images is not None:
+                rotation_angles = [int(angle) for angle in self.arguments.rotate_images.split(",")]
+                if len(rotation_angles) == 1:
+                    rotation_step_size = rotation_angles[0]
+                    self.rotation_angles = range(rotation_step_size, 360, rotation_step_size)
+                elif len(rotation_angles) > 1:
+                    self.rotation_angles = rotation_angles
         except AttributeError:
             pass
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -35,7 +35,7 @@ def get_image_paths(directory, exclude=[], debug=False):
 def rotate_image(image, angle, rotated_width=None, rotated_height=None):
     height, width = image.shape[:2]
     image_center = (width/2, height/2)
-    rotation_matrix = cv2.getRotationMatrix2D(image_center, angle, 1.)
+    rotation_matrix = cv2.getRotationMatrix2D(image_center, -1.*angle, 1.)
     if rotated_width is None or rotated_height is None:
         abs_cos = abs(rotation_matrix[0, 0])
         abs_sin = abs(rotation_matrix[0, 1])

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,6 +1,7 @@
 import cv2
 import sys
 from os.path import basename, exists
+import numpy as np
 
 from pathlib import Path
 from scandir import scandir
@@ -31,19 +32,10 @@ def get_image_paths(directory, exclude=[], debug=False):
 
     return dir_contents
 
+# From: https://stackoverflow.com/questions/9041681/opencv-python-rotate-image-by-x-degrees-around-specific-point
 def rotate_image(image, angle):
-    ''' Rotates an image by 90, 180 or 270 degrees. Positive for clockwise, negative for 
-        counterclockwise '''
-    if angle < 0: angle = sum((360, angle))
-    if angle == 90:
-        image = cv2.flip(cv2.transpose(image),flipCode=1)
-    elif angle == 180:
-        image = cv2.flip(image,flipCode=-1)
-    elif angle == 270:
-        image = cv2.flip(cv2.transpose(image),flipCode=0)
-    else:
-        print('Unsupported image rotation angle: {}. Image unmodified'.format(angle))
-    return image
+    center = tuple(np.array([image.shape[0], image.shape[1]]) / 2)
+    return cv2.warpAffine(image, cv2.getRotationMatrix2D(center, angle, 1.0), (image.shape[1], image.shape[0]))
 
 # From: https://stackoverflow.com/questions/7323664/python-generator-pre-fetch
 import threading

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,7 +1,6 @@
 import cv2
 import sys
 from os.path import basename, exists
-import numpy as np
 
 from pathlib import Path
 from scandir import scandir
@@ -32,10 +31,21 @@ def get_image_paths(directory, exclude=[], debug=False):
 
     return dir_contents
 
-# From: https://stackoverflow.com/questions/9041681/opencv-python-rotate-image-by-x-degrees-around-specific-point
-def rotate_image(image, angle):
-    center = tuple(np.array([image.shape[0], image.shape[1]]) / 2)
-    return cv2.warpAffine(image, cv2.getRotationMatrix2D(center, angle, 1.0), (image.shape[1], image.shape[0]))
+# From: https://stackoverflow.com/questions/22041699/rotate-an-image-without-cropping-in-opencv-in-c
+def rotate_image(image, angle, rotated_width=None, rotated_height=None):
+    height, width = image.shape[:2]
+    image_center = (width/2, height/2)
+    rotation_matrix = cv2.getRotationMatrix2D(image_center, angle, 1.)
+    if rotated_width is None or rotated_height is None:
+        abs_cos = abs(rotation_matrix[0, 0])
+        abs_sin = abs(rotation_matrix[0, 1])
+        if rotated_width is None:
+            rotated_width = int(height*abs_sin + width*abs_cos)
+        if rotated_height is None:
+            rotated_height = int(height*abs_cos + width*abs_sin)
+    rotation_matrix[0, 2] += rotated_width/2 - image_center[0]
+    rotation_matrix[1, 2] += rotated_height/2 - image_center[1]
+    return cv2.warpAffine(image, rotation_matrix, (rotated_width, rotated_height))
 
 # From: https://stackoverflow.com/questions/7323664/python-generator-pre-fetch
 import threading

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -242,10 +242,11 @@ class ConvertImage(DirectoryProcessor):
                         continue
                     # Check for image rotations and rotate before mapping face
                     if face.r != 0:
+                        height, width = image.shape[:2]
                         image = rotate_image(image, face.r)
                         image = converter.patch_image(image, face, 64 if "128" not in self.arguments.trainer else 128)
                         # TODO: This switch between 64 and 128 is a hack for now. We should have a separate cli option for size
-                        image = rotate_image(image, face.r * -1)
+                        image = rotate_image(image, face.r * -1, rotated_width=width, rotated_height=height)
                     else:
                         image = converter.patch_image(image, face, 64 if "128" not in self.arguments.trainer else 128)
                         # TODO: This switch between 64 and 128 is a hack for now. We should have a separate cli option for size

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -69,26 +69,12 @@ class ExtractTrainingData(DirectoryProcessor):
                             help="Draw landmarks for debug.")
 
         parser.add_argument('-r', '--rotate-images',
-                            type=str.lower,
+                            type=str,
                             dest="rotate_images",
-                            choices=("on", "off"),
-                            default="off",
-                            help="If a face isn't found, rotate the images through 90 degree "
-                                 "iterations to try to find a face. Can find more faces at the "
-                                 "cost of extraction speed.")
-
-        parser.add_argument('-ra', '--rotation-angle',
-                            type=int,
-                            dest="rotation_angle",
-                            default=90,
-                            help="Angle to rotate the images with each step (if --rotate-images is on)")
-
-        parser.add_argument('-ral', '--rotation-angle-list',
-                            type=int,
-                            dest="rotation_angle_list",
-                            nargs='*',
                             default=None,
-                            help="List of angles to use (if --rotate-images is on)")
+                            help="If a face isn't found, rotate the images to try to find a face. Can find more faces at the "
+                                 "cost of extraction speed.  Pass in a single number to use increments of that size up to 360, "
+                                 "or pass in a list of numbers to enumerate exactly what angles to check.")
 
         parser.add_argument('-ae', '--align-eyes',
                             action="store_true",
@@ -157,7 +143,7 @@ class ExtractTrainingData(DirectoryProcessor):
         process_faces = [(idx, face) for idx, face in faces]
 
         # Run image rotator if requested and no faces found
-        if self.arguments.rotate_images == 'on' and len(process_faces) == 0:
+        if self.arguments.rotate_images is not None and len(process_faces) == 0:
             process_faces, image = self.imageRotator(image)
 
         rvals = []

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -143,7 +143,7 @@ class ExtractTrainingData(DirectoryProcessor):
         process_faces = [(idx, face) for idx, face in faces]
 
         # Run image rotator if requested and no faces found
-        if self.arguments.rotate_images is not None and len(process_faces) == 0:
+        if self.rotation_angles is not None and len(process_faces) == 0:
             process_faces, image = self.imageRotator(image)
 
         rvals = []

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -77,6 +77,12 @@ class ExtractTrainingData(DirectoryProcessor):
                                  "iterations to try to find a face. Can find more faces at the "
                                  "cost of extraction speed.")
 
+        parser.add_argument('-ra', '--rotation-angle',
+                            type=int,
+                            dest="rotation_angle",
+                            default=90,
+                            help="How much to rotate the images with each step if --rotate-images is on")
+
         parser.add_argument('-ae', '--align-eyes',
                             action="store_true",
                             dest="align_eyes",
@@ -124,9 +130,9 @@ class ExtractTrainingData(DirectoryProcessor):
         return filename, []
 
     def imageRotator(self, image):
-        ''' rotates the image through 90 degree iterations to find a face '''
-        angle = 90
-        while angle <= 270:
+        ''' rotates the image through arguments.rotation_angle degree iterations to find a face '''
+        angle = self.arguments.rotation_angle
+        while angle < 360:
             rotated_image = rotate_image(image, angle)
             faces = self.get_faces(rotated_image, rotation=angle)
             rotated_faces = [(idx, face) for idx, face in faces]
@@ -134,7 +140,7 @@ class ExtractTrainingData(DirectoryProcessor):
                 if self.arguments.verbose:
                     print('found face(s) by rotating image {} degrees'.format(angle))
                 break
-            angle += 90
+            angle += self.arguments.rotation_angle
         return rotated_faces, rotated_image
 
     def handleImage(self, image, filename):


### PR DESCRIPTION
Previously only 90, 180, and 270 degree rotations were supported.  This PR adds support for arbitrary-angle image rotations during extraction.

This PR adds two new command-line options to `extract`, both of which require `--rotate-images on` in order to be used:
- `--rotation-angle <step_size>` lets you adjust the step size (default is `90`, as before)
- `--rotation-angle-list <angle1> <angle2> <angle3> ...` lets you enumerate a list of angles to use

I think `--rotation-angle-list` can be especially useful because the user will often know what angles are relevant for their inputs.  For example, it is common for a person's head to tilt a bit to the left sometimes and a bit to the right sometimes, but never go completely sideways or upside-down.  In this case, specifying just a couple of angles such as `--rotation-angle-list 30 330` can expand the extractor's effectiveness considerably.