### PR TITLE
Only import DLIB related modules when required and minor import relocations

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -16,15 +16,17 @@ def import_faces_detect():
     ''' Import the faces_detect module only when it is required '''
     global detect_faces
     global DetectedFace
-    import lib.faces_detect 
-    detect_faces = lib.faces_detect.detect_faces
-    DetectedFace = lib.faces_detect.DetectedFace
+    if detect_faces is None or DetectedFace is None:
+        import lib.faces_detect 
+        detect_faces = lib.faces_detect.detect_faces
+        DetectedFace = lib.faces_detect.DetectedFace
 
 def import_FaceFilter():
     ''' Import the FaceFilter module only when it is required '''
     global FaceFilter
-    import lib.FaceFilter
-    FaceFilter = lib.FaceFilter.FaceFilter
+    if FaceFilter is None:
+        import lib.FaceFilter
+        FaceFilter = lib.FaceFilter.FaceFilter
 
 class FullPaths(argparse.Action):
     """Expand user- and relative-paths"""
@@ -155,8 +157,7 @@ class DirectoryProcessor(object):
         return os.path.exists(fn)
 
     def get_faces_alignments(self, filename, image):
-        if DetectedFace is None:
-            import_faces_detect()
+        import_faces_detect()
         faces_count = 0
         faces = self.faces_detected[os.path.basename(filename)]
         for rawface in faces:
@@ -177,8 +178,7 @@ class DirectoryProcessor(object):
             self.verify_output = True
 
     def get_faces(self, image, rotation=0):
-        if detect_faces is None:
-            import_faces_detect()
+        import_faces_detect()
         faces_count = 0
         faces = detect_faces(image, self.arguments.detector, self.arguments.verbose, rotation)
         
@@ -207,8 +207,7 @@ class DirectoryProcessor(object):
         filter_files = list(filter(lambda fn: Path(fn).exists(), filter_files))
         
         if filter_files:
-            if FaceFilter is None:
-                import_FaceFilter()
+            import_FaceFilter()
             print('Loading reference images for filtering: %s' % filter_files)
             return FaceFilter(filter_files, nfilter_files, self.arguments.ref_threshold)
 

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -7,26 +7,24 @@ from pathlib import Path
 from lib.utils import get_image_paths, get_folder, rotate_image
 from lib import Serializer
 
-''' The following are modules that require GPU usage so they should only be called 
-    if they are needed '''
+# DLIB is a GPU Memory hog, so the following modules should only be imported when required
 detect_faces = None
 DetectedFace = None
+FaceFilter = None
+
 def import_faces_detect():
     ''' Import the faces_detect module only when it is required '''
-    if 'lib.faces_detect' not in sys.modules:
-        global detect_faces
-        global DetectedFace
-        import lib.faces_detect 
-        detect_faces = lib.faces_detect.detect_faces
-        DetectedFace = lib.faces_detect.DetectedFace
+    global detect_faces
+    global DetectedFace
+    import lib.faces_detect 
+    detect_faces = lib.faces_detect.detect_faces
+    DetectedFace = lib.faces_detect.DetectedFace
 
-FaceFilter = None
 def import_FaceFilter():
     ''' Import the FaceFilter module only when it is required '''
-    if 'lib.FaceFilter' not in sys.modules:
-        global FaceFilter
-        import lib.FaceFilter
-        FaceFilter = lib.FaceFilter.FaceFilter
+    global FaceFilter
+    import lib.FaceFilter
+    FaceFilter = lib.FaceFilter.FaceFilter
 
 class FullPaths(argparse.Action):
     """Expand user- and relative-paths"""

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -14,10 +14,11 @@ def import_tensorflow_keras():
     ''' Import the TensorFlow and keras set_session modules only when they are required '''
     global tf
     global set_session
-    import tensorflow
-    import keras.backend.tensorflow_backend
-    tf = tensorflow
-    set_session = keras.backend.tensorflow_backend.set_session
+    if tf is None or set_session is None:
+        import tensorflow
+        import keras.backend.tensorflow_backend
+        tf = tensorflow
+        set_session = keras.backend.tensorflow_backend.set_session
 
 class TrainingProcessor(object):
     arguments = None
@@ -193,8 +194,7 @@ class TrainingProcessor(object):
             exit(1)
 
     def set_tf_allow_growth(self):
-        if tf is None or set_session is None:
-            import_tensorflow_keras()
+        import_tensorflow_keras()
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
         config.gpu_options.visible_device_list="0"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -8,20 +8,16 @@ from lib.utils import get_image_paths, get_folder
 from lib.cli import FullPaths
 from plugins.PluginLoader import PluginLoader
 
-''' The following are modules that require GPU usage so they should only be called 
-    if they are needed '''
 tf = None
 set_session = None
 def import_tensorflow_keras():
     ''' Import the TensorFlow and keras set_session modules only when they are required '''
-    if 'tensorflow' not in sys.modules:
-        global tf
-        import tensorflow
-        tf = tensorflow
-    if 'keras.backend.tensorflow_backend' not in sys.modules:
-        global set_session
-        import keras.backend.tensorflow_backend
-        set_session = keras.backend.tensorflow_backend.set_session
+    global tf
+    global set_session
+    import tensorflow
+    import keras.backend.tensorflow_backend
+    tf = tensorflow
+    set_session = keras.backend.tensorflow_backend.set_session
 
 class TrainingProcessor(object):
     arguments = None

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -197,7 +197,7 @@ class TrainingProcessor(object):
             exit(1)
 
     def set_tf_allow_growth(self):
-        if tf is None:
+        if tf is None or set_session is None:
             import_tensorflow_keras()
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,6 +1,5 @@
 import cv2
 import numpy
-import sys
 import time
 
 import threading 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,7 +13,7 @@ from plugins.PluginLoader import PluginLoader
 tf = None
 set_session = None
 def import_tensorflow_keras():
-    ''' Import the faces_detect module only when it is required '''
+    ''' Import the TensorFlow and keras set_session modules only when they are required '''
     if 'tensorflow' not in sys.modules:
         global tf
         import tensorflow

--- a/tools/sort.py
+++ b/tools/sort.py
@@ -17,13 +17,15 @@ FaceLandmarksExtractor = None
 def import_face_recognition():
     ''' Import the face_recognition module only when it is required '''
     global face_recognition
-    import face_recognition
+    if face_recognition is None:
+        import face_recognition
 
 def import_FaceLandmarksExtractor():
     ''' Import the FaceLandmarksExtractor module only when it is required '''
     global FaceLandmarksExtractor
-    import lib.FaceLandmarksExtractor
-    FaceLandmarksExtractor = lib.FaceLandmarksExtractor
+    if FaceLandmarksExtractor is None:
+        import lib.FaceLandmarksExtractor
+        FaceLandmarksExtractor = lib.FaceLandmarksExtractor
 
 if sys.version_info[0] < 3:
     raise Exception("This program requires at least python3.2")
@@ -244,8 +246,7 @@ class SortProcessor(object):
         return img_list
 
     def sort_face(self):
-        if face_recognition is None:
-            import_face_recognition()
+        import_face_recognition()
        
         input_dir = self.arguments.input_dir
 
@@ -274,8 +275,7 @@ class SortProcessor(object):
         return img_list
 
     def sort_face_dissim(self):
-        if face_recognition is None:
-            import_face_recognition()
+        import_face_recognition()
         
         input_dir = self.arguments.input_dir
 
@@ -302,8 +302,7 @@ class SortProcessor(object):
         return img_list
 
     def sort_face_cnn(self):
-        if FaceLandmarksExtractor is None:
-            import_FaceLandmarksExtractor()
+        import_FaceLandmarksExtractor()
 
         input_dir = self.arguments.input_dir
 
@@ -332,7 +331,7 @@ class SortProcessor(object):
         return img_list
 
     def sort_face_cnn_dissim(self):
-        from lib import FaceLandmarksExtractor
+        import_FaceLandmarksExtractor()
 
         input_dir = self.arguments.input_dir
 
@@ -370,7 +369,7 @@ class SortProcessor(object):
             r = ( (fl[16][0]-fl[27][0]) + (fl[15][0]-fl[28][0]) + (fl[14][0]-fl[29][0]) ) / 3.0
             return r-l
             
-        from lib import FaceLandmarksExtractor
+        import_FaceLandmarksExtractor()
         input_dir = self.arguments.input_dir
     
         img_list = []
@@ -653,8 +652,7 @@ class SortProcessor(object):
         :return: img_list but with the comparative values that the chosen
         grouping method expects.
         """
-        if face_recognition is None:
-            import_face_recognition()
+        import_face_recognition()
 
         input_dir = self.arguments.input_dir
         print("Preparing to group...")
@@ -663,7 +661,7 @@ class SortProcessor(object):
         elif group_method == 'group_face':
             temp_list = [[x, face_recognition.face_encodings(cv2.imread(x))] for x in tqdm(self.find_images(input_dir), desc="Reloading", file=sys.stdout)]
         elif group_method == 'group_face_cnn':
-            from lib import FaceLandmarksExtractor
+            import_FaceLandmarksExtractor()
             temp_list = []
             for x in tqdm(self.find_images(input_dir), desc="Reloading", file=sys.stdout):
                 d = FaceLandmarksExtractor.extract(cv2.imread(x), 'cnn', True, input_is_predetected_face=True)
@@ -786,8 +784,7 @@ class SortProcessor(object):
 
     @staticmethod
     def get_avg_score_faces(f1encs, references):
-        if face_recognition is None:
-            import_face_recognition()
+        import_face_recognition()
         scores = []
         for f2encs in references:
             score = face_recognition.face_distance(f1encs, f2encs)[0]

--- a/tools/sort.py
+++ b/tools/sort.py
@@ -6,17 +6,29 @@ import operator
 import numpy as np
 import cv2
 from tqdm import tqdm
-import face_recognition
 from shutil import copyfile
 import json
 import re
 
+# DLIB is a GPU Memory hog, so the following modules should only be imported when required
+face_recognition = None
+FaceLandmarksExtractor = None
+
+def import_face_recognition():
+    ''' Import the face_recognition module only when it is required '''
+    global face_recognition
+    import face_recognition
+
+def import_FaceLandmarksExtractor():
+    ''' Import the FaceLandmarksExtractor module only when it is required '''
+    global FaceLandmarksExtractor
+    import lib.FaceLandmarksExtractor
+    FaceLandmarksExtractor = lib.FaceLandmarksExtractor
 
 if sys.version_info[0] < 3:
     raise Exception("This program requires at least python3.2")
 if sys.version_info[0] == 3 and sys.version_info[1] < 2:
     raise Exception("This program requires at least python3.2")
-
 
 class SortProcessor(object):
     def __init__(self, subparser, command, description='default'):
@@ -232,6 +244,9 @@ class SortProcessor(object):
         return img_list
 
     def sort_face(self):
+        if face_recognition is None:
+            import_face_recognition()
+       
         input_dir = self.arguments.input_dir
 
         print ("Sorting by face similarity...")
@@ -259,6 +274,9 @@ class SortProcessor(object):
         return img_list
 
     def sort_face_dissim(self):
+        if face_recognition is None:
+            import_face_recognition()
+        
         input_dir = self.arguments.input_dir
 
         print ("Sorting by face dissimilarity...")
@@ -284,7 +302,8 @@ class SortProcessor(object):
         return img_list
 
     def sort_face_cnn(self):
-        from lib import FaceLandmarksExtractor
+        if FaceLandmarksExtractor is None:
+            import_FaceLandmarksExtractor()
 
         input_dir = self.arguments.input_dir
 
@@ -634,6 +653,9 @@ class SortProcessor(object):
         :return: img_list but with the comparative values that the chosen
         grouping method expects.
         """
+        if face_recognition is None:
+            import_face_recognition()
+
         input_dir = self.arguments.input_dir
         print("Preparing to group...")
         if group_method == 'group_blur':
@@ -764,6 +786,8 @@ class SortProcessor(object):
 
     @staticmethod
     def get_avg_score_faces(f1encs, references):
+        if face_recognition is None:
+            import_face_recognition()
         scores = []
         for f2encs in references:
             score = face_recognition.face_distance(f1encs, f2encs)[0]


### PR DESCRIPTION
DLIB is a memory hog. Firing it up every time faceswap is run can lead to memory issues. This PR changes the imports so that any DLIB related modules are only loaded when required.

I have also moved any imports within the code that I have amended (e.g. tensorflow for allow_growth) to the top, so imports are all together. 

Threading was imported twice for train.py, so this has been fixed.

I think I got them all, but let me know if not. I tried to keep this at the highest level possible.

Tested working with extract, sort, train and convert.