### PR TITLE
Enable filename migration for lowmem

### DIFF
--- a/plugins/Model_LowMem/AutoEncoder.py
+++ b/plugins/Model_LowMem/AutoEncoder.py
@@ -1,8 +1,15 @@
 # AutoEncoder base classes
 
-encoderH5 = 'encoder.h5'
-decoder_AH5 = 'decoder_A.h5'
-decoder_BH5 = 'decoder_B.h5'
+encoderH5 = 'lowmem_encoder.h5'
+decoder_AH5 = 'lowmem_decoder_A.h5'
+decoder_BH5 = 'lowmem_decoder_B.h5'
+
+#Part of Filename migration, should be remopved some reasonable time after first added
+import os.path
+old_encoderH5 = 'encoder.h5'
+old_decoder_AH5 = 'decoder_A.h5'
+old_decoder_BH5 = 'decoder_B.h5'
+#End filename migration
 
 class AutoEncoder:
     def __init__(self, model_dir, gpus):
@@ -19,6 +26,17 @@ class AutoEncoder:
         (face_A,face_B) = (decoder_AH5, decoder_BH5) if not swapped else (decoder_BH5, decoder_AH5)
 
         try:
+            #Part of Filename migration, should be remopved some reasonable time after first added
+            if os.path.isfile(str(self.model_dir / old_encoderH5)):
+                print('Migrating to new filenames: ', end='')
+                if os.path.isfile(str(self.model_dir / encoderH5)) is not True:
+                    os.rename(str(self.model_dir / old_decoder_AH5), str(self.model_dir / decoder_AH5))
+                    os.rename(str(self.model_dir / old_decoder_BH5), str(self.model_dir / decoder_BH5))
+                    os.rename(str(self.model_dir / old_encoderH5), str(self.model_dir / encoderH5))
+                    print('Complete')
+                else:
+                    print('Failed due to existing files in folder.  Loading already migrated files')
+            #End filename migration
             self.encoder.load_weights(str(self.model_dir / encoderH5))
             self.decoder_A.load_weights(str(self.model_dir / face_A))
             self.decoder_B.load_weights(str(self.model_dir / face_B))


### PR DESCRIPTION
Right now lowmem and Original use the same filenames.  Since their models are incompatible, this could lead to failure by attempting to  load lowmem weights in original or vice versa.  This name change migration will rename the files existing lowmem models in order to prevent problems and make things more clear for the future.

We should keep this code in for a reasonable time, then remove the filename migration logic once everyone has migrated to the new filenames.  We may want to change original's filenames as well to match the new filename format but I have not done this for consistency reasons as it's less likely to get all users of original model to migrate to the new filenames than the lowmem model.

Recommend that all users either manually rename the lowmem files or run this commit against all their lowmem models to migrate to the new filenames.