### PR TITLE
#330 Save Model with Epoch flag

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -204,7 +204,6 @@ class TrainingProcessor(object):
                     self.save_now = False
                     
             model.save_weights()
-            print('Training complete\nModel has been saved')
             exit(0)
         except KeyboardInterrupt:
             try:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -197,12 +197,12 @@ class TrainingProcessor(object):
                     model.save_weights()
 
                 if self.stop:
-                    model.save_weights()
-                    exit()
+                    break
 
                 if self.save_now:
                     model.save_weights()
                     self.save_now = False
+                    
             model.save_weights()
             print('Training complete\nModel has been saved')
             exit(0)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -203,7 +203,9 @@ class TrainingProcessor(object):
                 if self.save_now:
                     model.save_weights()
                     self.save_now = False
-
+            model.save_weights()
+            print('Training complete\nModel has been saved')
+            exit(0)
         except KeyboardInterrupt:
             try:
                 model.save_weights()


### PR DESCRIPTION
#330 suggests that the network does not automatically save the model if an epoch is set manually via the --epoch flag.

The changes makes it so that the model is saved after the training loop.