### PR TITLE
GUI v0.1.1a - Fix GUI check for Windows non-use of DISPLAY environment variable

### DIFF
--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -1,6 +1,7 @@
 import sys
+import os
 
-from os import environ, path
+from os import path
 from threading import Thread
 
 from lib.cli import FullPaths
@@ -37,8 +38,9 @@ def import_tkinter(command):
     return True    
 
 def check_display(command):
-    # Check whether there is a display to output the GUI '''
-    if not environ.get('DISPLAY', None):
+    # Check whether there is a display to output the GUI. If running on Windows
+    # then assume not running in headless mode
+    if not os.environ.get('DISPLAY', None) and os.name != 'nt':
         if 'gui' in command:
             print ('Could not detect a display. The GUI has been disabled')
         return False


### PR DESCRIPTION
This is a fix which to stop a bug where Windows doesn't have the DISPLAY environment variable and therefore fails the check.

An assumption is made that if the scripts are being run on a Windows platform, then they will have a display as it is a graphical OS.

@Clorr @bryanlyon Please merge as this will effect all Windows users regardless of whether they use the GUI or not.

I have fired up an (underpowered) dev box so that I can more thoroughly test Windows builds going forward.