### PR TITLE
Fixed GAN128 multi gpu issue.

### DIFF
--- a/plugins/Model_GAN128/Model.py
+++ b/plugins/Model_GAN128/Model.py
@@ -45,7 +45,6 @@ class GANModel():
     def __init__(self, model_dir, gpus):
         self.model_dir = model_dir
         self.gpus = gpus
-        assert self.gpus == 1, "Error: GAN128 cannot use multiple gpus right now. See https://github.com/deepfakes/faceswap/issues/287"
 
         optimizer = Adam(1e-4, 0.5)
 
@@ -128,6 +127,8 @@ class GANModel():
         x = Input(shape=self.img_shape)
         netGA = Model(x, decoder_A(encoder(x)))
         netGB = Model(x, decoder_B(encoder(x)))
+        netGA.output_names = ["netGA_out_1", "netGA_out_2"] # Workarounds till https://github.com/keras-team/keras/issues/8962 is fixed.
+        netGB.output_names = ["netGB_out_1", "netGB_out_2"] #
 
         self.netGA_sm = netGA
         self.netGB_sm = netGB


### PR DESCRIPTION
Added explicit names to netGA and netGB's outputs to fix the name conflict error when using multiple gpus. 

This has been tested on a single GTX 1080 with no `-g` flag passed in and has been tested on a Azure NC12 VM with two K80 cards, both with no `-g` flag passed and with `-g 2`

This is replacing the assert added to solve #287