### PR TITLE
Model backups before saving

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -4,6 +4,7 @@ from os.path import basename, exists
 
 from pathlib import Path
 from scandir import scandir
+import os
 
 image_extensions = [".jpg", ".jpeg", ".png", ".tif", ".tiff"]
 
@@ -19,7 +20,7 @@ def get_image_paths(directory, exclude=[], debug=False):
     if not exists(directory):
         directory = get_folder(directory).path
 
-    dir_scanned = list(scandir(directory))
+    dir_scanned = sorted(os.scandir(directory), key=lambda x: x.name)
     for x in dir_scanned:
         if any([x.name.lower().endswith(ext) for ext in image_extensions]):
             if x.name in exclude_names:

--- a/plugins/Model_GAN/Model.py
+++ b/plugins/Model_GAN/Model.py
@@ -1,5 +1,7 @@
 # Based on the https://github.com/shaoanlu/faceswap-GAN repo (master/temp/faceswap_GAN_keras.ipynb)
 
+import os
+import shutil
 from keras.models import Model
 from keras.layers import *
 from keras.layers.advanced_activations import LeakyReLU
@@ -167,6 +169,11 @@ class GANModel():
         return True
 
     def save_weights(self):
+        model_dir = str(self.model_dir)
+        if os.path.isdir(model_dir + "_bk"):
+            shutil.rmtree(model_dir + "_bk")
+        shutil.move(model_dir,  model_dir + "_bk")
+        os.mkdir(model_dir)
         if self.gpus > 1:
             self.netGA_sm.save_weights(str(self.model_dir / netGAH5))
             self.netGB_sm.save_weights(str(self.model_dir / netGBH5))

--- a/plugins/Model_GAN128/Model.py
+++ b/plugins/Model_GAN128/Model.py
@@ -1,6 +1,8 @@
 # Based on the https://github.com/shaoanlu/faceswap-GAN repo
 # source : https://github.com/shaoanlu/faceswap-GAN/blob/master/FaceSwap_GAN_v2_sz128_train.ipynbtemp/faceswap_GAN_keras.ipynb
 
+import os
+import shutil
 from keras.models import Model
 from keras.layers import *
 from keras.layers.advanced_activations import LeakyReLU
@@ -184,6 +186,11 @@ class GANModel():
         return True
 
     def save_weights(self):
+        model_dir = str(self.model_dir)
+        if os.path.isdir(model_dir + "_bk"):
+            shutil.rmtree(model_dir + "_bk")
+        shutil.move(model_dir,  model_dir + "_bk")
+        os.mkdir(model_dir)
         if self.gpus > 1:
             self.netGA_sm.save_weights(str(self.model_dir / netGAH5))
             self.netGB_sm.save_weights(str(self.model_dir / netGBH5))

--- a/plugins/Model_IAE/AutoEncoder.py
+++ b/plugins/Model_IAE/AutoEncoder.py
@@ -1,5 +1,6 @@
 # Improved-AutoEncoder base classes
 
+import os, shutil
 
 encoderH5 = 'IAE_encoder.h5'
 decoderH5 = 'IAE_decoder.h5'
@@ -38,6 +39,11 @@ class AutoEncoder:
             return False
 
     def save_weights(self):
+        model_dir = str(self.model_dir)
+        if os.path.isdir(model_dir + "_bk"):
+            shutil.rmtree(model_dir + "_bk")
+        shutil.move(model_dir,  model_dir + "_bk")
+        os.mkdir(model_dir)
         self.encoder.save_weights(str(self.model_dir / encoderH5))
         self.decoder.save_weights(str(self.model_dir / decoderH5))
         self.inter_both.save_weights(str(self.model_dir / inter_bothH5))

--- a/plugins/Model_LowMem/AutoEncoder.py
+++ b/plugins/Model_LowMem/AutoEncoder.py
@@ -1,5 +1,7 @@
 # AutoEncoder base classes
 
+import os, shutil
+
 encoderH5 = 'encoder.h5'
 decoder_AH5 = 'decoder_A.h5'
 decoder_BH5 = 'decoder_B.h5'
@@ -30,6 +32,11 @@ class AutoEncoder:
             return False
 
     def save_weights(self):
+        model_dir = str(self.model_dir)
+        if os.path.isdir(model_dir + "_bk"):
+            shutil.rmtree(model_dir + "_bk")
+        shutil.move(model_dir,  model_dir + "_bk")
+        os.mkdir(model_dir)
         self.encoder.save_weights(str(self.model_dir / encoderH5))
         self.decoder_A.save_weights(str(self.model_dir / decoder_AH5))
         self.decoder_B.save_weights(str(self.model_dir / decoder_BH5))

--- a/plugins/Model_Original/AutoEncoder.py
+++ b/plugins/Model_Original/AutoEncoder.py
@@ -1,5 +1,7 @@
 # AutoEncoder base classes
 
+import os, shutil
+
 encoderH5 = 'encoder.h5'
 decoder_AH5 = 'decoder_A.h5'
 decoder_BH5 = 'decoder_B.h5'
@@ -30,6 +32,11 @@ class AutoEncoder:
             return False
 
     def save_weights(self):
+        model_dir = str(self.model_dir)
+        if os.path.isdir(model_dir + "_bk"):
+            shutil.rmtree(model_dir + "_bk")
+        shutil.move(model_dir,  model_dir + "_bk")
+        os.mkdir(model_dir)
         self.encoder.save_weights(str(self.model_dir / encoderH5))
         self.decoder_A.save_weights(str(self.model_dir / decoder_AH5))
         self.decoder_B.save_weights(str(self.model_dir / decoder_BH5))

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -244,7 +244,7 @@ class ConvertImage(DirectoryProcessor):
                 if self.have_face(filename):
                     faces = self.get_faces_alignments(filename, image)
                 else:
-                    print ('no alignment found for {}, skipping'.format(os.path.basename(filename)))
+                    tqdm.write ('no alignment found for {}, skipping'.format(os.path.basename(filename)))
                     continue
             else:
                 faces = self.get_faces(image)


### PR DESCRIPTION
This adds a backup mechanism - the model directory gets renamed into `<previous name>_bk` before saving weights and sorts images before processing, so the frame range parameter (`-fr`) makes sense (before the order of images would depend on the implementation of the file system/OS).