### PR TITLE
Refactor lib/Serializer.py, and other improvements.

### DIFF
--- a/lib/Serializer.py
+++ b/lib/Serializer.py
@@ -1,8 +1,21 @@
-import json, pickle
+#!/usr/bin/env python3
+"""
+Library providing convenient classes and methods for writing data to files.
+"""
+import sys
+import json
+import pickle
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
 class Serializer(object):
-    ext = "wtf"
-    woptions = "????"
-    roptions = "????"
+    ext = ""
+    woptions = ""
+    roptions = ""
 
     @classmethod
     def marshal(cls, input_data):
@@ -20,20 +33,11 @@ class YAMLSerializer(Serializer):
 
     @classmethod
     def marshal(cls, input_data):
-        try:
-            import yaml
-        except ImportError:
-            print("You must have PyYAML installed to use YAMLSerializer")
         return yaml.dump(input_data, default_flow_style=False)
 
     @classmethod
     def unmarshal(cls, input_string):
-        try:
-            import yaml
-        except ImportError:
-            print("You must have PyYAML installed to use YAMLSerializer")
         return yaml.load(input_string)
-
 
 
 class JSONSerializer(Serializer):
@@ -63,21 +67,28 @@ class PickleSerializer(Serializer):
     def unmarshal(cls, input_bytes):
         return pickle.loads(input_bytes)
 
+
 def get_serializer(serializer):
-    if serializer == "yaml":
-        return YAMLSerializer
     if serializer == "json":
         return JSONSerializer
-    if serializer == "pickle":
+    elif serializer == "pickle":
         return PickleSerializer
-    raise NotImplementedError()
-
-
-def get_serializer_fromext(ext):
-    if ext in (".yaml", ".yml"):
+    elif serializer == "yaml" and yaml is not None:
         return YAMLSerializer
+    elif serializer == "yaml" and yaml is None:
+        print("You must have PyYAML installed to use YAML as the serializer.\n"
+              "Switching to JSON as the serializer.", file=sys.stderr)
+    return JSONSerializer
+
+
+def get_serializer_from_ext(ext):
     if ext == ".json":
         return JSONSerializer
-    if ext == ".p":
+    elif ext == ".p":
         return PickleSerializer
-    raise NotImplementedError("No serializer matching that file type.")
+    elif ext in (".yaml", ".yml") and yaml is not None:
+        return YAMLSerializer
+    elif ext in (".yaml", ".yml") and yaml is None:
+        print("You must have PyYAML installed to use YAML as the serializer.\n"
+              "Switching to JSON as the serializer.", file=sys.stderr)
+    return JSONSerializer

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin python3
+#!/usr/bin/env python3
 """ Command Line Arguments """
 import argparse
 import os
@@ -236,7 +236,7 @@ class ExtractConvertArgs(FaceSwapArgs):
     def get_argument_list():
         """ Put the arguments in a list so that they are accessible from both
         argparse and gui """
-        alignments_filetypes = [["Serializers", ['json', 'yaml', 'p']],
+        alignments_filetypes = [["Serializers", ['json', 'p', 'yaml']],
                                 ["JSON", ["json"]],
                                 ["Pickle", ["p"]],
                                 ["YAML", ["yaml"]]]
@@ -261,15 +261,20 @@ class ExtractConvertArgs(FaceSwapArgs):
                               "filetypes": alignments_filetypes,
                               "type": str,
                               "dest": "alignments_path",
-                              "help": "optional path to alignments file"})
+                              "help": "Optional path to an alignments file."})
         argument_list.append({"opts": ("--serializer", ),
                               "type": str.lower,
                               "dest": "serializer",
+                              "default": "json",
                               "choices": ("json", "pickle", "yaml"),
-                              "help": "serializer for alignments file"})
+                              "help": "Serializer for alignments file. If "
+                                      "yaml is chosen and not available, then "
+                                      "json will be used as the default "
+                                      "fallback."})
         argument_list.append({"opts": ("-D", "--detector"),
                               "type": str,
-                              # case sensitive because this is used to load a plugin.
+                              # case sensitive because this is used to load a
+                              # plugin.
                               "choices": ("hog", "cnn", "all"),
                               "default": "hog",
                               "help": "Detector to use. 'cnn' detects many "

--- a/scripts/fsmedia.py
+++ b/scripts/fsmedia.py
@@ -1,4 +1,4 @@
-#!/usr/bin python3
+#!/usr/bin/env python3
 """ Holds the classes for the 3 main Faceswap 'media' objects for
     input (extract) and output (convert) tasks. Those being:
             Images
@@ -281,10 +281,10 @@ class Alignments(object):
         """ Set the serializer to be used for loading and saving alignments """
         if not self.args.serializer and self.args.alignments_path:
             ext = os.path.splitext(self.args.alignments_path)[-1]
-            serializer = Serializer.get_serializer_fromext(ext)
+            serializer = Serializer.get_serializer_from_ext(ext)
             print("Alignments Output: {}".format(self.args.alignments_path))
         else:
-            serializer = Serializer.get_serializer(self.args.serializer or "json")
+            serializer = Serializer.get_serializer(self.args.serializer)
         print("Using {} serializer".format(serializer.ext))
         return serializer
 


### PR DESCRIPTION
All:
Set correct python3 shebang.

lib/cli.py:
Fix some help documentation formatting and typos.
Set 'json' as the default value for '--serializer' argument.

lib/Serializer.py:
Refactor to properly handle PyYAML not being available.
Add docstring at top of the file.
Improve PEP8 conformity.

scripts/fsmedia.py:
Modify lib/Serializer.py method call to match new name.
Modify lib/Serializer.py method call to match not needing a default.

tools/sort.py:
Add new group by 'face-yaw' method.
Add docstring at top of the file.
Re-arrange argument order to make more sense.
Fix typos and line length issues in help documentation.
Change to use lib/Serializer.py to set the serializer and to write the log file.
Allow sort logging to use PyYAML.