### PR TITLE
Fix bug in docker image tf/tf:latest-gpu-py3

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,7 +1,7 @@
 FROM tensorflow/tensorflow:latest-py3
 
 RUN apt-get update -qq -y \
- && apt-get install -y cmake libsm6 libxrender1 libxext-dev python3-tk\
+ && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk\
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,14 +1,20 @@
 FROM tensorflow/tensorflow:latest-gpu-py3
 
 RUN apt-get update -qq -y \
- && apt-get install -y cmake libsm6 libxrender1 libxext-dev python3-tk\
+ && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk\
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /opt/
+RUN pip3 install cmake
 RUN pip3 install dlib --install-option=--yes --install-option=USE_AVX_INSTRUCTIONS
 RUN pip3 --no-cache-dir install -r /opt/requirements.txt && rm /opt/requirements.txt
 
+# patch for tensorflow:latest-gpu-py3 image
+RUN cd /usr/local/cuda/lib64 \
+ && mv stubs/libcuda.so ./ \
+ && ln -s libcuda.so libcuda.so.1 \
+ && ldconfig
 
 WORKDIR "/notebooks"
 CMD ["/run_jupyter.sh", "--allow-root"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,19 +81,26 @@ INFO    1. Install Docker
         2. Install latest CUDA
         CUDA: https://developer.nvidia.com/cuda-downloads
         
-        3. Install Nvidia-Docker
+        3. Install Nvidia-Docker & Restart Docker Service
         https://github.com/NVIDIA/nvidia-docker
         
         4. Build Docker Image For Faceswap
         docker build -t deepfakes-gpu -f Dockerfile.gpu .
         
         5. Mount faceswap volume and Run it
-        # without gui. tools.py gui working.
-        docker run -p 8888:8888 --hostname faceswap-gpu --name faceswap-gpu -v 
-/opt/faceswap:/srv faceswap-gpu
-        
-        # with gui. tools.py gui not working.
+        # without gui. tools.py gui not working.
         docker run -p 8888:8888 \
+            --hostname faceswap-gpu --name faceswap-gpu \
+            -v /opt/faceswap:/srv \
+            faceswap-gpu
+        
+        # with gui. tools.py gui working.
+        ## enable local access to X11 server
+        xhost +local:
+        ## enable nvidia device if working under bumblebee
+        echo ON > /proc/acpi/bbswitch
+        ## create container 
+        nvidia-docker run -p 8888:8888 \
             --hostname faceswap-gpu --name faceswap-gpu \
             -v /opt/faceswap:/srv \
             -v /tmp/.X11-unix:/tmp/.X11-unix \

--- a/setup.py
+++ b/setup.py
@@ -255,10 +255,16 @@ docker build -t deepfakes-cpu -f Dockerfile.cpu .
 
 3. Mount faceswap volume and Run it
 # without gui. tools.py gui not working.
-docker run -p 8888:8888 --hostname faceswap-cpu --name faceswap-cpu -v {path}:/srv faceswap-cpu
+docker run -p 8888:8888 \
+    --hostname faceswap-cpu --name faceswap-cpu \
+    -v {path}:/srv \
+    faceswap-cpu
 
 # with gui. tools.py gui working.
-docker run -p 8888:8888 \\
+## enable local access to X11 server
+xhost +local:
+## create container
+nvidia-docker run -p 8888:8888 \\
     --hostname faceswap-cpu --name faceswap-cpu \\
     -v {path}:/srv \\
     -v /tmp/.X11-unix:/tmp/.X11-unix \\
@@ -282,18 +288,26 @@ https://www.docker.com/community-edition
 2. Install latest CUDA
 CUDA: https://developer.nvidia.com/cuda-downloads
 
-3. Install Nvidia-Docker
+3. Install Nvidia-Docker & Restart Docker Service
 https://github.com/NVIDIA/nvidia-docker
 
 4. Build Docker Image For Faceswap
 docker build -t deepfakes-gpu -f Dockerfile.gpu .
 
 5. Mount faceswap volume and Run it
-# without gui. tools.py gui working.
-docker run -p 8888:8888 --hostname faceswap-gpu --name faceswap-gpu -v {path}:/srv faceswap-gpu
+# without gui. tools.py gui not working.
+docker run -p 8888:8888 \
+    --hostname faceswap-gpu --name faceswap-gpu \
+    -v {path}:/srv \
+    faceswap-gpu
 
-# with gui. tools.py gui not working.
-docker run -p 8888:8888 \\
+# with gui. tools.py gui working.
+## enable local access to X11 server
+xhost +local:
+## enable nvidia device if working under bumblebee
+echo ON > /proc/acpi/bbswitch
+## create container
+nvidia-docker run -p 8888:8888 \\
     --hostname faceswap-gpu --name faceswap-gpu \\
     -v {path}:/srv \\
     -v /tmp/.X11-unix:/tmp/.X11-unix \\


### PR DESCRIPTION
This is a bug fix in latest tf-gpu image, in which tensorflow cannot be load.

Altho this may be fixed later, I think it matters to commit a hot fix and btw, update some documentation.