### PR TITLE
fix typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,16 +256,16 @@ docker build -t deepfakes-cpu -f Dockerfile.cpu .
 3. Mount faceswap volume and Run it
 # without gui. tools.py gui not working.
 docker run -p 8888:8888 \
-    --hostname faceswap-cpu --name faceswap-cpu \
+    --hostname deepfakes-cpu --name deepfakes-cpu \
     -v {path}:/srv \
-    faceswap-cpu
+    deepfakes-cpu
 
 # with gui. tools.py gui working.
 ## enable local access to X11 server
 xhost +local:
 ## create container
 nvidia-docker run -p 8888:8888 \\
-    --hostname faceswap-cpu --name faceswap-cpu \\
+    --hostname deepfakes-cpu --name deepfakes-cpu \\
     -v {path}:/srv \\
     -v /tmp/.X11-unix:/tmp/.X11-unix \\
     -e DISPLAY=unix$DISPLAY \\
@@ -273,11 +273,11 @@ nvidia-docker run -p 8888:8888 \\
     -e VIDEO_GID=`getent group video | cut -d: -f3` \\
     -e GID=`id -g` \\
     -e UID=`id -u` \\
-    faceswap-cpu
+    deepfakes-cpu
 
 
 4. Open a new terminal to run faceswap.py in /srv
-docker exec -it faceswap-cpu bash
+docker exec -it deepfakes-cpu bash
 """.format(path=sys.path[0]))
     INFO("That's all you need to do with a docker. Have fun.")
 
@@ -297,9 +297,9 @@ docker build -t deepfakes-gpu -f Dockerfile.gpu .
 5. Mount faceswap volume and Run it
 # without gui. tools.py gui not working.
 docker run -p 8888:8888 \
-    --hostname faceswap-gpu --name faceswap-gpu \
+    --hostname deepfakes-gpu --name deepfakes-gpu \
     -v {path}:/srv \
-    faceswap-gpu
+    deepfakes-gpu
 
 # with gui. tools.py gui working.
 ## enable local access to X11 server
@@ -308,7 +308,7 @@ xhost +local:
 echo ON > /proc/acpi/bbswitch
 ## create container
 nvidia-docker run -p 8888:8888 \\
-    --hostname faceswap-gpu --name faceswap-gpu \\
+    --hostname deepfakes-gpu --name deepfakes-gpu \\
     -v {path}:/srv \\
     -v /tmp/.X11-unix:/tmp/.X11-unix \\
     -e DISPLAY=unix$DISPLAY \\
@@ -316,10 +316,10 @@ nvidia-docker run -p 8888:8888 \\
     -e VIDEO_GID=`getent group video | cut -d: -f3` \\
     -e GID=`id -g` \\
     -e UID=`id -u` \\
-    faceswap-gpu
+    deepfakes-gpu
 
 6. Open a new terminal to interact with the project
-docker exec faceswap-gpu python /srv/tools.py gui
+docker exec deepfakes-gpu python /srv/tools.py gui
 """.format(path=sys.path[0]))
 
 def Tips_2_1():


### PR DESCRIPTION
Previously the container name was ` deepfakes-cpu` or `deepfakes-gpu` but then it was used as `faceswap-cpu` or `faceswap-gpu`. Now they are consistent.