### PR TITLE
Requirements version bump

### DIFF
--- a/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
+++ b/lib/FaceLandmarksExtractor/FaceLandmarksExtractor.py
@@ -22,7 +22,7 @@ def onExit():
     for detector in dlib_detectors:
         del detector
         
-class TorchBatchNorm2D(keras.engine.topology.Layer):
+class TorchBatchNorm2D(keras.engine.base_layer.Layer):
     def __init__(self, axis=-1, momentum=0.99, epsilon=1e-3, **kwargs):
         super(TorchBatchNorm2D, self).__init__(**kwargs)
         self.supports_masking = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,16 @@
 pathlib==1.0.1
-scandir==1.6
-h5py==2.7.1
-Keras==2.1.2
-opencv-python==3.3.0.10
+scandir==1.7
+h5py==2.8.0
+Keras==2.2.0
+opencv-python==3.4.1.15
 scikit-image
+face_recognition
 cmake
 dlib
-face-recognition
 tqdm
-matplotlib
+matplotlib==2.2.2
 ffmpy==0.2.2
 
 # tensorflow is included within the docker image.
 # If you are looking for dependencies for a manual install,
 # you may want to install tensorflow-gpu==1.4.0 for CUDA 8.0 or tensorflow-gpu>=1.5.0 for CUDA 9.0
-
-# cmake needs to be installed before compiling dlib.


### PR DESCRIPTION
This bumps the versions of:
- scandir
- h5py
- Keras
- opencv-python

to their latest vesions. 

Virtual Environment will need to be setup again to make use of these.