### PR TITLE
remove leftover faces alignments job

### DIFF
--- a/tools/alignments.py
+++ b/tools/alignments.py
@@ -38,7 +38,7 @@ class Alignments(object):
             job = Draw(self.alignments, self.args)
         elif self.args.job == "extract":
             job = Extract(self.alignments, self.args)
-        elif self.args.job in("missing-alignments", "missing-frames",
+        elif self.args.job in("missing-alignments", "missing-frames", "leftover-faces",
                               "multi-faces", "no-faces"):
             job = Check(self.alignments, self.args)
         elif self.args.job == "remove":
@@ -559,9 +559,9 @@ class Check(object):
                   "there will be nothing to move. "
                   "Defaulting to output: console")
             self.output = "console"
-        elif self.type == "faces" and self.job != "multi-faces":
+        elif self.type == "faces" and self.job != "multi-faces" and self.job != "leftover-faces":
             print("WARNING: The selected folder is not valid. Only folder set "
-                  "with '-fc' is supported for 'multi-faces'")
+                  "with '-fc' is supported for 'multi-faces' and 'leftover-faces'")
             exit(0)
 
     def compile_output(self):
@@ -610,6 +610,17 @@ class Check(object):
         for item in self.alignments_data.keys():
             if item not in self.items:
                 yield item
+
+    def get_leftover_faces(self):
+        """yield each face that isn't in the alignments file."""
+        self.output_message = "Faces missing from the alignments file"
+        for item in self.items:
+            frame_id = item[2] + item[1]
+
+            if frame_id not in self.alignments_data or self.alignments_data[frame_id] <= item[3]:
+                yield item[0] + item[1]
+            
+        print("Done")
 
     def output_results(self):
         """ Output the results in the requested format """

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -11,6 +11,7 @@ class AlignmentsArgs(FaceSwapArgs):
 
     def get_argument_list(self):
         frames_dir = "\n\tMust Pass in a frames folder (-fr)."
+        faces_dir = "\n\tMust Pass in a faces folder (-fc)."
         frames_or_faces_dir = ("\n\tMust Pass in either a frames folder \n\t"
                                "OR a faces folder (-fr or -fc).")
         output_opts = "\n\tUse the output option (-o) to process\n\tresults."
@@ -19,7 +20,7 @@ class AlignmentsArgs(FaceSwapArgs):
                               "type": str,
                               "choices": ("draw", "extract",
                                           "missing-alignments",
-                                          "missing-frames", "multi-faces",
+                                          "missing-frames", "leftover-faces", "multi-faces",
                                           "no-faces", "reformat", "remove"),
                               "required": True,
                               "help": "R|Choose which action you want to "
@@ -45,7 +46,11 @@ class AlignmentsArgs(FaceSwapArgs):
                                       "the alignments\n\tfile that do not "
                                       "appear within the frames\n\t"
                                       "folder." + output_opts +
-                                      frames_dir + "\n"
+                                      frames_dir + "\n" +
+                                      "'leftover-faces': Identify faces in "
+                                      "the faces folder\n\tthat do not exist "
+                                      "in the alignments file." + output_opts +
+                                      faces_dir + "\n"
                                       "'multi-faces': Identify where multiple "
                                       "faces exist\n\twithin the alignments "
                                       "file." + output_opts +


### PR DESCRIPTION
Added a new job in the alignments tool which tells you which faces are in the faces folder, but aren't found in the alignments file.

This is useful for me because my alignments file is saved every 10 frames it goes through. And if it gets stopped, I want to delete the pngs it made that aren't saved in the alignments file.