### PR TITLE
Uses sys.executable for python subprocess cmd from GUI

### DIFF
--- a/lib/gui/wrapper.py
+++ b/lib/gui/wrapper.py
@@ -98,7 +98,7 @@ class ProcessWrapper(object):
         script = "{}.{}".format(category, "py")
         pathexecscript = os.path.join(self.pathscript, script)
 
-        args = ["python"] if generate else ["python", "-u"]
+        args = [sys.executable] if generate else [sys.executable, "-u"]
         args.extend([pathexecscript, command])
 
         for cliopt in self.cliopts.gen_cli_arguments(command):


### PR DESCRIPTION
Currently the GUI calls `python ARGUMENTS` which on some systems might be python2.
This is the case on my Debian install fe.

This PR simply changes `python` to whatever the GUI was started with by using sys.executable.