### PR TITLE
fix docker run command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,7 +92,7 @@ INFO    1. Install Docker
         docker run -p 8888:8888 \
             --hostname faceswap-gpu --name faceswap-gpu \
             -v /opt/faceswap:/srv \
-            faceswap-gpu
+            deepfakes-gpu
         
         # with gui. tools.py gui working.
         ## enable local access to X11 server
@@ -109,7 +109,7 @@ INFO    1. Install Docker
             -e VIDEO_GID=`getent group video | cut -d: -f3` \
             -e GID=`id -g` \
             -e UID=`id -u` \
-            faceswap-gpu
+            deepfakes-gpu
         
         6. Open a new terminal to interact with the project
         docker exec faceswap-gpu python /srv/tools.py gui


### PR DESCRIPTION
the install instruction does not work with the provided commands. If the image is named "deepfakes-gpu" then this is what needs to be started with `docker run`. fixed that in steps 5 and 6.