### PR TITLE
Add Face Hashes to Alignments

### DIFF
--- a/lib/alignments.py
+++ b/lib/alignments.py
@@ -209,10 +209,10 @@ class Alignments():
         logger.debug("Deleting face %s for frame '%s'", idx, frame)
         idx = int(idx)
         if idx + 1 > self.count_faces_in_frame(frame):
-            logger.debug("No face to delete")
+            logger.debug("No face to delete: (frame: '%s', idx %s)", frame, idx)
             return False
         del self.data[frame][idx]
-        logger.debug("Deleted face")
+        logger.debug("Deleted face: (frame: '%s', idx %s)", frame, idx)
         return True
 
     def add_face(self, frame, alignment):

--- a/lib/alignments.py
+++ b/lib/alignments.py
@@ -220,6 +220,23 @@ class Alignments():
         logger.debug("Updating face %s for frame '%s'", idx, frame)
         self.data[frame][idx] = alignment
 
+    def filter_hashes(self, hashlist, filter_out=False):
+        """ Filter in or out faces that match the hashlist
+
+            filter_out=True: Remove faces that match in the hashlist
+            filter_out=False: Remove faces that are not in the hashlist
+        """
+        hashset = set(hashlist)
+        for filename, frame in self.data.items():
+            for idx, face in reversed(list(enumerate(frame))):
+                if ((filter_out and face.get("hash", None) in hashset) or
+                        (not filter_out and face.get("hash", None) not in hashset)):
+                    logger.verbose("Filtering out face: (filename: %s, index: %s)", filename, idx)
+                    del frame[idx]
+                else:
+                    logger.trace("Not filtering out face: (filename: %s, index: %s)",
+                                 filename, idx)
+
     # << GENERATORS >> #
 
     def yield_faces(self):
@@ -328,3 +345,27 @@ class Alignments():
         r_mat[1, 2] += rotated_height/2 - center[1]
         logger.trace("Returning rotation matrix: %s", r_mat)
         return r_mat
+
+    # <Face Hashes> #
+    # The old index based method of face matching is problematic.
+    # The SHA1 Hash of the extracted face is now stored in the alignments file.
+    # This has it's own issues, but they are far reduced from the index/filename method
+    # This can eventually be removed
+    def get_legacy_no_hashes(self):
+        """ Get alignments without face hashes """
+        logger.debug("Getting alignments without face hashes")
+        keys = list()
+        for key, val in self.data.items():
+            for alignment in val:
+                if "hash" not in alignment.keys():
+                    keys.append(key)
+                    break
+        logger.debug("Got alignments without face hashes: %s", len(keys))
+        return keys
+
+    def add_face_hashes(self, frame_name, hashes):
+        """ Backward compatability fix. Add face hash to alignments """
+        logger.trace("Adding face hash: (frame: '%s', hashes: %s)", frame_name, hashes)
+        faces = self.get_faces_in_frame(frame_name)
+        for idx, i_hash in hashes.items():
+            faces[idx]["hash"] = i_hash

--- a/lib/alignments.py
+++ b/lib/alignments.py
@@ -59,6 +59,14 @@ class Alignments():
         logger.trace(retval)
         return retval
 
+    @property
+    def hashes_to_frame(self):
+        """ Return a dict of each face_hash with their parent
+            frame name and their index in the frame """
+        return{face["hash"]: (frame_name, idx)
+               for frame_name, faces in self.data.items()
+               for idx, face in enumerate(faces)}
+
     # << INIT FUNCTIONS >> #
 
     @staticmethod
@@ -155,13 +163,13 @@ class Alignments():
     def frame_exists(self, frame):
         """ return path of images that have faces """
         retval = frame in self.data.keys()
-        logger.trace(retval)
+        logger.trace("'%s': %s", frame, retval)
         return retval
 
     def frame_has_faces(self, frame):
         """ Return true if frame exists and has faces """
         retval = bool(self.data.get(frame, list()))
-        logger.trace(retval)
+        logger.trace("'%s': %s", frame, retval)
         return retval
 
     def frame_has_multiple_faces(self, frame):
@@ -170,7 +178,7 @@ class Alignments():
             retval = False
         else:
             retval = bool(len(self.data.get(frame, list())) > 1)
-        logger.trace(retval)
+        logger.trace("'%s': %s", frame, retval)
         return retval
 
     # << DATA >> #
@@ -367,5 +375,11 @@ class Alignments():
         """ Backward compatability fix. Add face hash to alignments """
         logger.trace("Adding face hash: (frame: '%s', hashes: %s)", frame_name, hashes)
         faces = self.get_faces_in_frame(frame_name)
+        count_match = len(faces) - len(hashes)
+        if count_match != 0:
+            msg = "more" if count_match > 0 else "fewer"
+            logger.warning("There are %s %s face(s) in the alignments file than exist in the "
+                           "faces folder. Check your sources for frame '%s'.",
+                           abs(count_match), msg, frame_name)
         for idx, i_hash in hashes.items():
             faces[idx]["hash"] = i_hash

--- a/lib/faces_detect.py
+++ b/lib/faces_detect.py
@@ -21,6 +21,7 @@ class DetectedFace():
         self.h = h
         self.frame_dims = frame_dims
         self.landmarksXY = landmarksXY
+        self.hash = None  # Hash must be set when the file is saved due to image compression
 
         self.aligned = dict()
         logger.trace("Initialized %s", self.__class__.__name__)
@@ -62,7 +63,11 @@ class DetectedFace():
                            self.x: self.x + self.w]
 
     def to_alignment(self):
-        """ Convert a detected face to alignment dict """
+        """ Convert a detected face to alignment dict
+
+            NB: frame_dims should be the height and width
+                of the original frame. """
+
         alignment = dict()
         alignment["x"] = self.x
         alignment["w"] = self.w
@@ -70,6 +75,7 @@ class DetectedFace():
         alignment["h"] = self.h
         alignment["frame_dims"] = self.frame_dims
         alignment["landmarksXY"] = self.landmarksXY
+        alignment["hash"] = self.hash
         logger.trace("Returning: %s", alignment)
         return alignment
 
@@ -83,7 +89,8 @@ class DetectedFace():
         self.h = alignment["h"]
         self.frame_dims = alignment["frame_dims"]
         self.landmarksXY = alignment["landmarksXY"]
-        if image.any():
+        self.hash = alignment["hash"]
+        if image is not None and image.any():
             self.image_to_face(image)
         logger.trace("Created from alignment: (x: %s, w: %s, y: %s. h: %s, "
                      "frame_dims: %s, landmarks: %s)",
@@ -100,11 +107,14 @@ class DetectedFace():
         self.aligned["padding"] = padding
         self.aligned["align_eyes"] = align_eyes
         self.aligned["matrix"] = get_align_mat(self, size, align_eyes)
-        self.aligned["face"] = AlignerExtract().transform(
-            image,
-            self.aligned["matrix"],
-            size,
-            padding)
+        if image is None:
+            self.aligned["face"] = None
+        else:
+            self.aligned["face"] = AlignerExtract().transform(
+                image,
+                self.aligned["matrix"],
+                size,
+                padding)
         logger.trace("Loaded aligned face: %s", {key: val
                                                  for key, val in self.aligned.items()
                                                  if key != "face"})

--- a/lib/faces_detect.py
+++ b/lib/faces_detect.py
@@ -89,7 +89,8 @@ class DetectedFace():
         self.h = alignment["h"]
         self.frame_dims = alignment["frame_dims"]
         self.landmarksXY = alignment["landmarksXY"]
-        self.hash = alignment["hash"]
+        # Manual tool does not know the final hash so default to None
+        self.hash = alignment.get("hash", None)
         if image is not None and image.any():
             self.image_to_face(image)
         logger.trace("Created from alignment: (x: %s, w: %s, y: %s. h: %s, "

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -64,7 +64,7 @@ def hash_image_file(filename):
     """ Return the filename with it's sha1 hash """
     img = cv2.imread(filename)  # pylint: disable=no-member
     img_hash = sha1(img).hexdigest()
-    logger.trace("filename: %s, hash: %s", filename, img_hash)
+    logger.trace("filename: '%s', hash: %s", filename, img_hash)
     return img_hash
 
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import warnings
 
+from hashlib import sha1
 from pathlib import Path
 from re import finditer
 from time import time
@@ -57,6 +58,23 @@ def get_image_paths(directory):
 
     logger.debug("Returning %s images", len(dir_contents))
     return dir_contents
+
+
+def hash_image_file(filename):
+    """ Return the filename with it's sha1 hash """
+    img = cv2.imread(filename)  # pylint: disable=no-member
+    img_hash = sha1(img).hexdigest()
+    logger.trace("filename: %s, hash: %s", filename, img_hash)
+    return img_hash
+
+
+def hash_encode_image(image, extension):
+    """ Encode the image, get the hash and return the hash with
+        encoded image """
+    img = cv2.imencode(extension, image)[1]  # pylint: disable=no-member
+    f_hash = sha1(
+        cv2.imdecode(img, cv2.IMREAD_UNCHANGED)).hexdigest()  # pylint: disable=no-member
+    return f_hash, img
 
 
 def backup_file(directory, filename):

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -14,7 +14,7 @@ from scripts.fsmedia import Alignments, Images, PostProcess, Utils
 from lib.faces_detect import DetectedFace
 from lib.multithreading import BackgroundGenerator, SpawnProcess
 from lib.queue_manager import queue_manager
-from lib.utils import get_folder, get_image_paths
+from lib.utils import get_folder, get_image_paths, hash_image_file
 
 from plugins.plugin_loader import PluginLoader
 
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class Convert():
     """ The convert process. """
     def __init__(self, arguments):
+        logger.debug("Initializing %s: (args: %s)", self.__class__.__name__, arguments)
         self.args = arguments
         self.output_dir = get_folder(self.args.output_dir)
         self.extract_faces = False
@@ -33,12 +34,13 @@ class Convert():
         self.alignments = Alignments(self.args, False)
 
         # Update Legacy alignments
-        Legacy(self.alignments, self.images.input_images)
+        Legacy(self.alignments, self.images.input_images, arguments.input_aligned_dir)
 
         self.post_process = PostProcess(arguments)
         self.verify_output = False
 
-        self.opts = OptionalActions(self.args, self.images.input_images)
+        self.opts = OptionalActions(self.args, self.images.input_images, self.alignments)
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def process(self):
         """ Original & LowMem models go with Adjust or Masked converter
@@ -207,22 +209,16 @@ class Convert():
             skip = self.opts.check_skipframe(filename)
 
             if not skip:
-                for idx, face in enumerate(faces):
-                    image = self.convert_one_face(converter,
-                                                  (filename, image, idx, face))
+                for face in faces:
+                    image = self.convert_one_face(converter, image, face)
                 filename = str(self.output_dir / Path(filename).name)
                 cv2.imwrite(filename, image)  # pylint: disable=no-member
         except Exception as err:
             logger.error("Failed to convert image: '%s'. Reason: %s", filename, err)
             raise
 
-    def convert_one_face(self, converter, imagevars):
+    def convert_one_face(self, converter, image, face):
         """ Perform the conversion on the given frame for a single face """
-        filename, image, idx, face = imagevars
-
-        if self.opts.check_skipface(filename, idx):
-            return image
-
         # TODO: This switch between 64 and 128 is a hack for now.
         # We should have a separate cli option for size
         size = 128 if (self.args.trainer.strip().lower()
@@ -237,37 +233,55 @@ class Convert():
 class OptionalActions():
     """ Process the optional actions for convert """
 
-    def __init__(self, args, input_images):
+    def __init__(self, args, input_images, alignments):
+        logger.debug("Initializing %s", self.__class__.__name__)
         self.args = args
         self.input_images = input_images
-
-        self.faces_to_swap = self.get_aligned_directory()
-
+        self.alignments = alignments
         self.frame_ranges = self.get_frame_ranges()
         self.imageidxre = re.compile(r"[^(mp4)](\d+)(?!.*\d)")
 
+        self.remove_skipped_faces()
+        logger.debug("Initialized %s", self.__class__.__name__)
+
     # SKIP FACES #
-    def get_aligned_directory(self):
+    def remove_skipped_faces(self):
+        """ Remove deleted faces from the loaded alignments """
+        logger.debug("Filtering Faces")
+        face_hashes = self.get_face_hashes()
+        if not face_hashes:
+            logger.debug("No face hashes. Not skipping any faces")
+            return
+        pre_face_count = self.alignments.faces_count
+        self.alignments.filter_hashes(face_hashes, filter_out=False)
+        logger.info("Faces filtered out: %s", pre_face_count - self.alignments.faces_count)
+
+    def get_face_hashes(self):
         """ Check for the existence of an aligned directory for identifying
-            which faces in the target frames should be swapped """
-        faces_to_swap = None
+            which faces in the target frames should be swapped.
+            If it exists, obtain the hashes of the faces in the folder """
+        face_hashes = list()
         input_aligned_dir = self.args.input_aligned_dir
 
         if input_aligned_dir is None:
-            logger.info("Aligned directory not specified. All faces listed in the "
-                        "alignments file will be converted")
+            logger.verbose("Aligned directory not specified. All faces listed in the "
+                           "alignments file will be converted")
         elif not os.path.isdir(input_aligned_dir):
             logger.warning("Aligned directory not found. All faces listed in the "
                            "alignments file will be converted")
         else:
-            faces_to_swap = [Path(path)
-                             for path in get_image_paths(input_aligned_dir)]
-            if not faces_to_swap:
-                logger.warning("Aligned directory is empty, no faces will be converted!")
-            elif len(faces_to_swap) <= len(self.input_images) / 3:
-                logger.warning("Aligned directory contains an amount of images much less than "
-                               "the input, are you sure this is the right directory?")
-        return faces_to_swap
+            file_list = [path for path in get_image_paths(input_aligned_dir)]
+            logger.info("Getting Face Hashes for selected Aligned Images")
+            for face in tqdm(file_list, desc="Hashing Faces"):
+                face_hashes.append(hash_image_file(face))
+            logger.debug("Face Hashes: %s", (len(face_hashes)))
+            if not face_hashes:
+                logger.error("Aligned directory is empty, no faces will be converted!")
+                exit(1)
+            elif len(face_hashes) <= len(self.input_images) / 3:
+                logger.warning("Aligned directory contains far fewer images than the input "
+                               "directory, are you sure this is the right folder?")
+        return face_hashes
 
     # SKIP FRAME RANGES #
     def get_frame_ranges(self):
@@ -293,20 +307,6 @@ class OptionalActions():
             skipframe = "discard"
         return skipframe
 
-    def check_skipface(self, filename, face_idx):
-        """ Check whether face is to be skipped """
-        if self.faces_to_swap is None:
-            return False
-        face_name = "{}_{}{}".format(Path(filename).stem,
-                                     face_idx,
-                                     Path(filename).suffix)
-        face_file = Path(self.args.input_aligned_dir) / Path(face_name)
-        skip_face = face_file not in self.faces_to_swap
-        if skip_face:
-            logger.info("face %s for frame '%s' was deleted, skipping",
-                        face_idx, os.path.basename(filename))
-        return skip_face
-
 
 class Legacy():
     """ Update legacy alignments:
@@ -314,25 +314,31 @@ class Legacy():
         - Add frame dimensions
         - Rotate landmarks and bounding boxes on legacy alignments
         and remove the 'r' parameter """
-    def __init__(self, alignments, frames):
+    def __init__(self, alignments, frames, faces_dir):
         self.alignments = alignments
         self.frames = {os.path.basename(frame): frame
                        for frame in frames}
-        self.process()
+        self.process(faces_dir)
 
-    def process(self):
+    def process(self, faces_dir):
         """ Run the rotate alignments process """
         no_dims = self.alignments.get_legacy_no_dims()
         rotated = self.alignments.get_legacy_rotation()
-        if not no_dims and not rotated:
+        hashes = self.alignments.get_legacy_no_hashes()
+        if not no_dims and not rotated and not hashes:
             return
         if no_dims:
             logger.info("Legacy landmarks found. Adding frame dimensions...")
             self.add_dimensions(no_dims)
+            self.alignments.save()
         if rotated:
             logger.info("Legacy rotated frames found. Converting...")
             self.rotate_landmarks(rotated)
-        self.alignments.save()
+            self.alignments.save()
+        if hashes and faces_dir:
+            logger.info("Legacy alignments found. Adding Face Hashes...")
+            self.add_hashes(hashes, faces_dir)
+            self.alignments.save()
 
     def add_dimensions(self, no_dims):
         """ Add width and height of original frame to alignments """
@@ -347,5 +353,27 @@ class Legacy():
         """ Rotate the landmarks """
         for rotate_item in tqdm(rotated, desc="Rotating Landmarks"):
             if rotate_item not in self.frames.keys():
+                logger.debug("Skipping missing frame: '%s'", rotate_item)
                 continue
             self.alignments.rotate_existing_landmarks(rotate_item)
+
+    def add_hashes(self, hashes, faces_dir):
+        """ Add Face Hashes to the alignments file """
+        all_faces = dict()
+        face_files = sorted(face for face in os.listdir(faces_dir) if "_" in face)
+        for face in face_files:
+            filename, extension = os.path.splitext(face)
+            index = filename[filename.rfind("_") + 1:]
+            if not index.isdigit():
+                continue
+            orig_frame = filename[:filename.rfind("_")] + extension
+            all_faces.setdefault(orig_frame, dict())[int(index)] = os.path.join(faces_dir, face)
+
+        for frame in tqdm(hashes):
+            if frame not in all_faces.keys():
+                logger.warning("Skipping missing frame: '%s'", frame)
+                continue
+            hash_faces = all_faces[frame]
+            for index, face_path in hash_faces.items():
+                hash_faces[index] = hash_image_file(face_path)
+            self.alignments.add_face_hashes(frame, hash_faces)

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -313,7 +313,9 @@ class Legacy():
 
         - Add frame dimensions
         - Rotate landmarks and bounding boxes on legacy alignments
-        and remove the 'r' parameter """
+        and remove the 'r' parameter
+        - Add face hashes to alignments file
+        """
     def __init__(self, alignments, frames, faces_dir):
         self.alignments = alignments
         self.frames = {os.path.basename(frame): frame

--- a/tools/alignments.py
+++ b/tools/alignments.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """ Tools for manipulating the alignments seralized file """
 
-# TODO merge alignments
 from lib.utils import set_system_verbosity
-from .lib_alignments import (AlignmentData, Check, Draw, Extract, Legacy,
-                             Manual, Reformat, RemoveAlignments, Sort, Spatial)
+from .lib_alignments import (AlignmentData, Check, Draw, # noqa pylint: disable=unused-import
+                             Extract, Legacy, Manual, Reformat, Rename,
+                             RemoveAlignments, Sort, Spatial)
 
 
 class Alignments():
@@ -14,14 +14,12 @@ class Alignments():
         set_system_verbosity()
 
         dest_format = self.get_dest_format()
-        self.alignments = AlignmentData(self.args.alignments_file,
-                                        dest_format)
+        self.alignments = AlignmentData(self.args.alignments_file, dest_format)
 
     def get_dest_format(self):
         """ Set the destination format for Alignments """
         dest_format = None
-        if (hasattr(self.args, 'alignment_format')
-                and self.args.alignment_format):
+        if hasattr(self.args, 'alignment_format') and self.args.alignment_format:
             dest_format = self.args.alignment_format
         return dest_format
 
@@ -34,8 +32,7 @@ class Alignments():
         elif self.args.job.startswith("sort-"):
             job = Sort
         elif self.args.job in("missing-alignments", "missing-frames",
-                              "multi-faces", "leftover-faces",
-                              "no-faces"):
+                              "multi-faces", "leftover-faces", "no-faces"):
             job = Check
         else:
             job = globals()[self.args.job.title()]

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -23,11 +23,10 @@ class AlignmentsArgs(FaceSwapArgs):
 
             "opts": ("-j", "--job"),
             "type": str,
-            "choices": ("draw", "extract", "extract-large", "manual",
-                        "missing-alignments", "missing-frames", "legacy",
-                        "leftover-faces", "multi-faces", "no-faces",
-                        "reformat", "remove-faces", "remove-frames",
-                        "sort-x", "sort-y", "spatial"),
+            "choices": ("draw", "extract", "extract-large", "manual", "missing-alignments",
+                        "missing-frames", "legacy", "leftover-faces", "multi-faces", "no-faces",
+                        "reformat", "remove-faces", "remove-frames", "rename", "sort-x", "sort-y",
+                        "spatial", "update-hashes"),
             "required": True,
             "help": "R|Choose which action you want to perform.\n"
                     "NB: All actions require an alignments file (-a) to"
@@ -51,9 +50,10 @@ class AlignmentsArgs(FaceSwapArgs):
                     "\n'missing-frames': Identify frames in the alignments"
                     "\n\tfile that do not appear within the frames"
                     "\n\tfolder." + output_opts + frames_dir +
-                    "\n'legacy': This updates legacy alignments to the latest "
-                    "\n\tformat by adding frame dimensions and rotating "
-                    "\n\tthe landmarks and bounding boxes" + frames_dir +
+                    "\n'legacy': This updates legacy alignments to the latest"
+                    "\n\tformat by adding frame dimensions, rotating the"
+                    "\n\tlandmarks and bounding boxes and adding face_hashes" +
+                    frames_and_faces_dir +
                     "\n'leftover-faces': Identify faces in the faces"
                     "\n\tfolder that do not exist in the alignments file."
                     + output_opts + faces_dir +
@@ -80,6 +80,10 @@ class AlignmentsArgs(FaceSwapArgs):
                     "\n\twill be backed up. A different file format for"
                     "\n\tthe alignments file can optionally be specified"
                     "\n\t(-fmt)." + frames_dir +
+                    "\n'rename' - Rename faces to correspond with their"
+                    "\n\tparent frame and position index in the alignments"
+                    "\n\tfile (i.e. how they are named after running"
+                    "\n\textract)." + faces_dir +
                     "\n'sort-x' - Re-index the alignments from left to"
                     "\n\tright. For alignments with multiple faces this will"
                     "\n\tensure that the left-most face is at index 0"
@@ -90,7 +94,7 @@ class AlignmentsArgs(FaceSwapArgs):
                     "\n\tensure that the top-most face is at index 0"
                     "\n\tOptionally pass in a faces folder (-fc) to also"
                     "\n\trename extracted faces."
-                    "\n'spatial' - Perform spatial and temporal filtering to "
+                    "\n'spatial' - Perform spatial and temporal filtering to"
                     "\n\tsmooth alignments (EXPERIMENTAL!)"})
         argument_list.append({"opts": ("-a", "--alignments_file"),
                               "action": FileFullPaths,

--- a/tools/lib_alignments/__init__.py
+++ b/tools/lib_alignments/__init__.py
@@ -1,4 +1,4 @@
 from tools.lib_alignments.media import AlignmentData, ExtractedFaces, Faces, Frames
 from tools.lib_alignments.annotate import Annotate
-from tools.lib_alignments.jobs import Check, Draw, Extract, Legacy, Reformat, RemoveAlignments, Sort, Spatial
+from tools.lib_alignments.jobs import Check, Draw, Extract, Legacy, Reformat, RemoveAlignments, Rename, Sort, Spatial
 from tools.lib_alignments.jobs_manual import Manual

--- a/tools/lib_alignments/annotate.py
+++ b/tools/lib_alignments/annotate.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 """ Tools for annotating an input image """
 
-from cv2 import (  # pylint: disable=no-name-in-module
-    rectangle, circle, polylines, putText,
-    FONT_HERSHEY_DUPLEX, fillPoly, addWeighted)
-from numpy import array, int32, uint8, zeros
+import logging
+
+import cv2
+import numpy as np
 
 from lib.align_eyes import FACIAL_LANDMARKS_IDXS
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class Annotate():
     """ Annotate an input image """
 
     def __init__(self, image, alignments, original_roi=None):
+        logger.debug("Initializing %s: (alignments: %s, original_roi: %s)",
+                     self.__class__.__name__, alignments, original_roi)
         self.image = image
         self.alignments = alignments
         self.roi = original_roi
@@ -22,21 +26,27 @@ class Annotate():
                        4: (255, 255, 0),
                        5: (255, 0, 255),
                        6: (0, 255, 255)}
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def draw_black_image(self):
         """ Change image to black at correct dimensions """
+        logger.trace("Drawing black image")
         height, width = self.image.shape[:2]
-        self.image = zeros((height, width, 3), uint8)
+        self.image = np.zeros((height, width, 3), np.uint8)
 
     def draw_bounding_box(self, color_id=1, thickness=1):
         """ Draw the bounding box around faces """
         color = self.colors[color_id]
         for alignment in self.alignments:
             top_left = (alignment["x"], alignment["y"])
-            bottom_right = (alignment["x"] + alignment["w"],
-                            alignment["y"] + alignment["h"])
-            rectangle(self.image, top_left, bottom_right,
-                      color, thickness)
+            bottom_right = (alignment["x"] + alignment["w"], alignment["y"] + alignment["h"])
+            logger.trace("Drawing bounding box: (top_left: %s, bottom_right: %s, color: %s, "
+                         "thickness: %s)", top_left, bottom_right, color, thickness)
+            cv2.rectangle(self.image,  # pylint: disable=no-member
+                          top_left,
+                          bottom_right,
+                          color,
+                          thickness)
 
     def draw_extract_box(self, color_id=2, thickness=1):
         """ Draw the extracted face box """
@@ -44,29 +54,47 @@ class Annotate():
             return
         color = self.colors[color_id]
         for idx, roi in enumerate(self.roi):
+            logger.trace("Drawing Extract Box: (idx: %s, roi: %s)", idx, roi)
             top_left = [point for point in roi.squeeze()[0]]
             top_left = (top_left[0], top_left[1] - 10)
-            putText(self.image, str(idx), top_left, FONT_HERSHEY_DUPLEX, 1.0,
-                    color, thickness)
-            polylines(self.image, [roi], True, color, thickness)
+            cv2.putText(self.image,  # pylint: disable=no-member
+                        str(idx),
+                        top_left,
+                        cv2.FONT_HERSHEY_DUPLEX,  # pylint: disable=no-member
+                        1.0,
+                        color,
+                        thickness)
+            cv2.polylines(self.image, [roi], True, color, thickness)  # pylint: disable=no-member
 
     def draw_landmarks(self, color_id=3, radius=1):
         """ Draw the facial landmarks """
         color = self.colors[color_id]
         for alignment in self.alignments:
             landmarks = alignment["landmarksXY"]
+            logger.trace("Drawing Landmarks: (landmarks: %s, color: %s, radius: %s)",
+                         landmarks, color, radius)
             for (pos_x, pos_y) in landmarks:
-                circle(self.image, (pos_x, pos_y), radius, color, -1)
+                cv2.circle(self.image,  # pylint: disable=no-member
+                           (pos_x, pos_y),
+                           radius,
+                           color,
+                           -1)
 
     def draw_landmarks_mesh(self, color_id=4, thickness=1):
         """ Draw the facial landmarks """
         color = self.colors[color_id]
         for alignment in self.alignments:
             landmarks = alignment["landmarksXY"]
+            logger.trace("Drawing Landmarks Mesh: (landmarks: %s, color: %s, thickness: %s)",
+                         landmarks, color, thickness)
             for key, val in FACIAL_LANDMARKS_IDXS.items():
-                points = array([landmarks[val[0]:val[1]]], int32)
+                points = np.array([landmarks[val[0]:val[1]]], np.int32)
                 fill_poly = bool(key in ("right_eye", "left_eye", "mouth"))
-                polylines(self.image, points, fill_poly, color, thickness)
+                cv2.polylines(self.image,  # pylint: disable=no-member
+                              points,
+                              fill_poly,
+                              color,
+                              thickness)
 
     def draw_grey_out_faces(self, live_face):
         """ Grey out all faces except target """
@@ -76,5 +104,11 @@ class Annotate():
         overlay = self.image.copy()
         for idx, roi in enumerate(self.roi):
             if idx != int(live_face):
-                fillPoly(overlay, roi, (0, 0, 0))
-        addWeighted(overlay, alpha, self.image, 1 - alpha, 0, self.image)
+                logger.trace("Greying out face: (idx: %s, roi: %s)", idx, roi)
+                cv2.fillPoly(overlay, roi, (0, 0, 0))  # pylint: disable=no-member
+        cv2.addWeighted(overlay,  # pylint: disable=no-member
+                        alpha,
+                        self.image,
+                        1 - alpha,
+                        0,
+                        self.image)

--- a/tools/lib_alignments/jobs.py
+++ b/tools/lib_alignments/jobs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """ Tools for manipulating the alignments seralized file """
+# TODO merge alignments
 
 import logging
 import os
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class Check():
     """ Frames and faces checking tasks """
     def __init__(self, alignments, arguments):
+        logger.debug("Initializing %s: (arguments: %s)", self.__class__.__name__, arguments)
         self.alignments = alignments
         self.job = arguments.job
         self.type = None
@@ -28,6 +30,7 @@ class Check():
         self.items = self.get_items()
 
         self.output_message = ""
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def get_source_dir(self, arguments):
         """ Set the correct source dir """
@@ -40,6 +43,7 @@ class Check():
         else:
             logger.error("No source folder (-fr or -fc) was provided")
             exit(0)
+        logger.debug("type: '%s', source_dir: '%s'", self.type, source_dir)
         return source_dir
 
     def get_items(self):
@@ -61,8 +65,7 @@ class Check():
             logger.warning("Missing_frames was selected with move output, but there will "
                            "be nothing to move. Defaulting to output: console")
             self.output = "console"
-        elif self.type == "faces" and self.job not in ("multi-faces",
-                                                       "leftover-faces"):
+        elif self.type == "faces" and self.job not in ("multi-faces", "leftover-faces"):
             logger.warning("The selected folder is not valid. Only folder set with '-fc' is "
                            "supported for 'multi-faces' and 'leftover-faces'")
             exit(0)
@@ -71,14 +74,17 @@ class Check():
         """ Compile list of frames that meet criteria """
         action = self.job.replace("-", "_")
         processor = getattr(self, "get_{}".format(action))
+        logger.debug("Processor: %s", processor)
         return [item for item in processor()]
 
     def get_no_faces(self):
         """ yield each frame that has no face match in alignments file """
         self.output_message = "Frames with no faces"
-        for frame in tqdm(self.items, total=len(self.items)):
+        for frame in tqdm(self.items, desc=self.output_message):
+            logger.trace(frame)
             frame_name = frame["frame_fullname"]
             if not self.alignments.frame_has_faces(frame_name):
+                logger.debug("Returning: '%s'", frame_name)
                 yield frame_name
 
     def get_multi_faces(self):
@@ -86,30 +92,36 @@ class Check():
             matched in alignments file """
         if self.type == "faces":
             self.output_message = "Multiple faces in frame"
-            frame_key = "frame_name"
+            frame_key = "face_hash"
             retval_key = "face_fullname"
         elif self.type == "frames":
             self.output_message = "Frames with multiple faces"
             frame_key = "frame_fullname"
             retval_key = "frame_fullname"
+        logger.debug("frame_key: '%s', retval_key: '%s'", frame_key, retval_key)
 
-        for item in tqdm(self.items, total=len(self.items)):
+        for item in tqdm(self.items, desc=self.output_message):
             frame = item[frame_key]
             if self.type == "faces":
-                frame = self.alignments.get_full_frame_name(frame)
+                frame, idx = self.alignments.hashes_to_frame[frame]
             retval = item[retval_key]
 
             if self.alignments.frame_has_multiple_faces(frame):
+                if self.type == "faces":
+                    # Add correct alignments index for moving faces
+                    retval = (retval, idx)
+                logger.trace("Returning: '%s'", retval)
                 yield retval
 
     def get_missing_alignments(self):
         """ yield each frame that does not exist in alignments file """
         self.output_message = "Frames missing from alignments file"
         exclude_filetypes = ["yaml", "yml", "p", "json", "txt"]
-        for frame in tqdm(self.items, total=len(self.items)):
+        for frame in tqdm(self.items, desc=self.output_message):
             frame_name = frame["frame_fullname"]
             if (frame["frame_extension"] not in exclude_filetypes
                     and not self.alignments.frame_exists(frame_name)):
+                logger.debug("Returning: '%s'", frame_name)
                 yield frame_name
 
     def get_missing_frames(self):
@@ -117,19 +129,18 @@ class Check():
             not have a matching file """
         self.output_message = "Missing frames that are in alignments file"
         frames = [item["frame_fullname"] for item in self.items]
-        for frame in tqdm(self.alignments.data.keys(),
-                          total=len(self.alignments.frames_count)):
+        for frame in tqdm(self.alignments.data.keys(), desc=self.output_message):
             if frame not in frames:
+                logger.debug("Returning: '%s'", frame)
                 yield frame
 
     def get_leftover_faces(self):
         """yield each face that isn't in the alignments file."""
         self.output_message = "Faces missing from the alignments file"
-        for face in tqdm(self.items, total=len(self.items)):
-            frame = self.alignments.get_full_frame_name(face["frame_name"])
-            alignment_faces = self.alignments.count_faces_in_frame(frame)
-
-            if alignment_faces <= face["face_index"]:
+        for face in tqdm(self.items, desc=self.output_message):
+            f_hash = face["face_hash"]
+            if not self.alignments.hashes_to_frame.get(f_hash, None):
+                logger.debug("Returning: '%s'", face["face_fullname"])
                 yield face["face_fullname"]
 
     def output_results(self, items_output):
@@ -140,21 +151,24 @@ class Check():
         if self.output == "move":
             self.move_file(items_output)
             return
+        if self.job == "multi-faces":
+            # Strip the index for printed/file output
+            items_output = [item[0] for item in items_output]
         output_message = "-----------------------------------------------\r\n"
         output_message += " {} ({})\r\n".format(self.output_message,
                                                 len(items_output))
         output_message += "-----------------------------------------------\r\n"
         output_message += "\r\n".join([frame for frame in items_output])
         if self.output == "console":
-            print("\n" + output_message)
+            for line in output_message.splitlines():
+                logger.info(line)
         if self.output == "file":
             self.output_file(output_message, len(items_output))
 
     def output_file(self, output_message, items_discovered):
         """ Save the output to a text file in the frames directory """
         now = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = self.output_message.replace(" ", "_").lower()
-        filename += "_" + now + ".txt"
+        filename = "{}_{}.txt".format(self.output_message.replace(" ", "_").lower(), now)
         output_file = os.path.join(self.source_dir, filename)
         logger.info("Saving %s result(s) to '%s'", items_discovered, output_file)
         with open(output_file, "w") as f_output:
@@ -163,11 +177,12 @@ class Check():
     def move_file(self, items_output):
         """ Move the identified frames to a new subfolder """
         now = datetime.now().strftime("%Y%m%d_%H%M%S")
-        folder_name = self.output_message.replace(" ", "_").lower()
-        folder_name += "_" + now
+        folder_name = "{}_{}".format(self.output_message.replace(" ", "_").lower(), now)
         output_folder = os.path.join(self.source_dir, folder_name)
+        logger.debug("Creating folder: '%s'", output_folder)
         os.makedirs(output_folder)
         move = getattr(self, "move_{}".format(self.type))
+        logger.debug("Move function: %s", move)
         move(output_folder, items_output)
 
     def move_frames(self, output_folder, items_output):
@@ -176,54 +191,54 @@ class Check():
         for frame in items_output:
             src = os.path.join(self.source_dir, frame)
             dst = os.path.join(output_folder, frame)
+            logger.debug("Moving: '%s' to '%s'", src, dst)
             os.rename(src, dst)
 
     def move_faces(self, output_folder, items_output):
         """ Make additional subdirs for each face that appears
             Enables easier manual sorting """
         logger.info("Moving %s faces(s) to '%s'", len(items_output), output_folder)
-        for frame in items_output:
-            idx = frame[frame.rfind("_") + 1:frame.rfind(".")]
+        for frame, idx in items_output:
             src = os.path.join(self.source_dir, frame)
-            dst_folder = os.path.join(output_folder, idx)
+            dst_folder = os.path.join(output_folder, str(idx))
             if not os.path.isdir(dst_folder):
+                logger.debug("Creating folder: '%s'", dst_folder)
                 os.makedirs(dst_folder)
             dst = os.path.join(dst_folder, frame)
+            logger.debug("Moving: '%s' to '%s'", src, dst)
             os.rename(src, dst)
 
 
 class Draw():
     """ Draw Alignments on passed in images """
     def __init__(self, alignments, arguments):
+        logger.debug("Initializing %s: (arguments: %s)", self.__class__.__name__, arguments)
         self.arguments = arguments
         self.alignments = alignments
         self.frames = Frames(arguments.frames_dir)
         self.output_folder = self.set_output()
         self.extracted_faces = None
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def set_output(self):
         """ Set the output folder path """
         now = datetime.now().strftime("%Y%m%d_%H%M%S")
         folder_name = "drawn_landmarks_{}".format(now)
         output_folder = os.path.join(self.frames.folder, folder_name)
+        logger.debug("Creating folder: '%s'", output_folder)
         os.makedirs(output_folder)
         return output_folder
 
     def process(self):
         """ Run the draw alignments process """
-        legacy = Legacy(self.alignments, self.arguments,
-                        frames=self.frames, child_process=True)
+        legacy = Legacy(self.alignments, None, frames=self.frames, child_process=True)
         legacy.process()
 
         logger.info("[DRAW LANDMARKS]")  # Tidy up cli output
-        self.extracted_faces = ExtractedFaces(
-            self.frames,
-            self.alignments,
-            align_eyes=self.arguments.align_eyes)
+        self.extracted_faces = ExtractedFaces(self.frames, self.alignments,
+                                              align_eyes=self.arguments.align_eyes)
         frames_drawn = 0
-        for frame in tqdm(self.frames.file_list_sorted,
-                          desc="Drawing landmarks"):
-
+        for frame in tqdm(self.frames.file_list_sorted, desc="Drawing landmarks"):
             frame_name = frame["frame_fullname"]
 
             if not self.alignments.frame_exists(frame_name):
@@ -236,6 +251,7 @@ class Draw():
 
     def annotate_image(self, frame):
         """ Draw the alignments """
+        logger.trace("Annotating frame: '%s'", frame)
         alignments = self.alignments.get_faces_in_frame(frame)
         image = self.frames.load_image(frame)
         self.extracted_faces.get_faces_in_frame(frame)
@@ -255,13 +271,15 @@ class Extract():
     """ Re-extract faces from source frames based on
         Alignment data """
     def __init__(self, alignments, arguments):
+        logger.debug("Initializing %s: (arguments: %s)", self.__class__.__name__, arguments)
         self.alignments = alignments
+        self.arguments = arguments
         self.type = arguments.job.replace("extract-", "")
         self.faces_dir = arguments.faces_dir
         self.frames = Frames(arguments.frames_dir)
-        self.extracted_faces = ExtractedFaces(self.frames,
-                                              self.alignments,
+        self.extracted_faces = ExtractedFaces(self.frames, self.alignments,
                                               align_eyes=arguments.align_eyes)
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def process(self):
         """ Run extraction """
@@ -287,9 +305,7 @@ class Extract():
         """ Export the faces """
         extracted_faces = 0
 
-        for frame in tqdm(self.frames.file_list_sorted,
-                          desc="Saving extracted faces"):
-
+        for frame in tqdm(self.frames.file_list_sorted, desc="Saving extracted faces"):
             frame_name = frame["frame_fullname"]
 
             if not self.alignments.frame_exists(frame_name):
@@ -297,18 +313,29 @@ class Extract():
                 continue
             extracted_faces += self.output_faces(frame)
 
+        if extracted_faces != 0 and self.type != "large":
+            self.alignments.save()
         logger.info("%s face(s) extracted", extracted_faces)
 
     def output_faces(self, frame):
         """ Output the frame's faces to file """
+        logger.trace("Outputting frame: %s", frame)
         face_count = 0
         frame_fullname = frame["frame_fullname"]
         frame_name = frame["frame_name"]
+        extension = os.path.splitext(frame_fullname)[1]
         faces = self.select_valid_faces(frame_fullname)
 
         for idx, face in enumerate(faces):
-            output = "{}_{}{}".format(frame_name, str(idx), ".png")
-            self.frames.save_image(self.faces_dir, output, face.aligned_face)
+            output = "{}_{}{}".format(frame_name, str(idx), extension)
+            if self.type == "large":
+                self.frames.save_image(self.faces_dir, output, face.aligned_face)
+            else:
+                output = os.path.join(self.faces_dir, output)
+                f_hash = self.extracted_faces.save_face_with_hash(output,
+                                                                  extension,
+                                                                  face.aligned_face)
+                self.alignments.data[frame_fullname][idx]["hash"] = f_hash
             face_count += 1
         return face_count
 
@@ -316,47 +343,50 @@ class Extract():
         """ Return valid faces for extraction """
         faces = self.extracted_faces.get_faces_in_frame(frame)
         if self.type != "large":
-            return faces
-        valid_faces = list()
-        sizes = self.extracted_faces.get_roi_size_for_frame(frame)
-        for idx, size in enumerate(sizes):
-            if size >= self.extracted_faces.size:
-                valid_faces.append(faces[idx])
+            valid_faces = faces
+        else:
+            sizes = self.extracted_faces.get_roi_size_for_frame(frame)
+            valid_faces = [faces[idx]
+                           for idx, size in enumerate(sizes)
+                           if size >= self.extracted_faces.size]
+        logger.trace("frame: '%s', total_faces: %s, valid_faces: %s",
+                     frame, len(faces), len(valid_faces))
         return valid_faces
 
 
 class Reformat():
     """ Reformat Alignment file """
     def __init__(self, alignments, arguments):
+        logger.debug("Initializing %s: (arguments: %s)", self.__class__.__name__, arguments)
         self.alignments = alignments
-        if self.alignments.file == "dfl":
-            self.faces = Faces(arguments.faces_dir, dfl=True)
+        if self.alignments.file == "dfl.json":
+            logger.debug("Loading DFL faces")
+            self.faces = Faces(arguments.faces_dir)
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def process(self):
         """ Run reformat """
         logger.info("[REFORMAT ALIGNMENTS]")  # Tidy up cli output
-        if self.alignments.file == "dfl":
+        if self.alignments.file == "dfl.json":
             self.alignments.data = self.load_dfl()
-            self.alignments.file = self.alignments.get_location(
-                self.faces.folder,
-                "alignments")
+            self.alignments.file = self.alignments.get_location(self.faces.folder, "alignments")
         self.alignments.save()
 
     def load_dfl(self):
         """ Load alignments from DeepFaceLab and format for Faceswap """
         alignments = dict()
-        for face in self.faces.file_list_sorted:
+        for face in tqdm(self.faces.file_list_sorted, desc="Converting DFL Faces"):
             if face["face_extension"] != ".png":
                 logger.verbose("'%s' is not a png. Skipping", face["face_fullname"])
                 continue
-
+            f_hash = face["face_hash"]
             fullpath = os.path.join(self.faces.folder, face["face_fullname"])
             dfl = self.get_dfl_alignment(fullpath)
 
             if not dfl:
                 continue
 
-            self.convert_dfl_alignment(dfl, alignments)
+            self.convert_dfl_alignment(dfl, f_hash, alignments)
         return alignments
 
     @staticmethod
@@ -376,34 +406,37 @@ class Reformat():
                 dfl.seek(chunk_start, os.SEEK_SET)
                 if chunk_name == b"fcWp":
                     chunk = dfl.read(chunk_length + 12)
-                    return pickle.loads(chunk[8:-4])
+                    retval = pickle.loads(chunk[8:-4])
+                    logger.trace("Loaded DFL Alignment: (filename: '%s', alignment: %s",
+                                 filename, retval)
+                    return retval
                 dfl.seek(chunk_length+12, os.SEEK_CUR)
             logger.error("Couldn't find DFL alignments: %s", filename)
 
     @staticmethod
-    def convert_dfl_alignment(dfl_alignments, alignments):
+    def convert_dfl_alignment(dfl_alignments, f_hash, alignments):
         """ Add DFL Alignments to alignments in Faceswap format """
         sourcefile = dfl_alignments["source_filename"]
-        if not alignments.get(sourcefile, None):
-            alignments[sourcefile] = list()
-
         left, top, right, bottom = dfl_alignments["source_rect"]
         alignment = {"x": left,
                      "w": right - left,
                      "y": top,
                      "h": bottom - top,
+                     "hash": f_hash,
                      "landmarksXY": dfl_alignments["source_landmarks"]}
-
-        alignments[sourcefile].append(alignment)
+        logger.trace("Adding alignment: (frame: '%s', alignment: %s", sourcefile, alignment)
+        alignments.setdefault(sourcefile, list()).append(alignment)
 
 
 class RemoveAlignments():
     """ Remove items from alignments file """
     def __init__(self, alignments, arguments):
+        logger.debug("Initializing %s: (arguments: %s)", self.__class__.__name__, arguments)
         self.alignments = alignments
         self.type = arguments.job.replace("remove-", "")
         self.items = self.get_items(arguments)
         self.removed = set()
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def get_items(self, arguments):
         """ Set the correct items to process """
@@ -416,18 +449,23 @@ class RemoveAlignments():
 
     def process(self):
         """ run removal """
+        if self.type == "faces":
+            legacy = Legacy(self.alignments, None, faces=self.items, child_process=True)
+            legacy.process()
+
         logger.info("[REMOVE ALIGNMENTS DATA]")  # Tidy up cli output
         del_count = 0
+        task = getattr(self, "remove_{}".format(self.type))
 
-        iterator = self.alignments.yield_faces
         if self.type == "frames":
-            iterator = list(item[3] for item in iterator())
-
-        for item in tqdm(iterator() if self.type == "faces" else iterator,
-                         desc="Processing alignments file",
-                         total=self.alignments.frames_count):
-            task = getattr(self, "remove_{}".format(self.type))
-            del_count += task(item)
+            logger.debug("Removing Frames")
+            for frame in tqdm(list(item[3] for item in self.alignments.yield_faces()),
+                              desc="Removing Frames",
+                              total=self.alignments.frames_count):
+                del_count += task(frame)
+        else:
+            logger.debug("Removing Faces")
+            del_count = task()
 
         if del_count == 0:
             logger.info("No changes made to alignments file. Exiting")
@@ -437,86 +475,45 @@ class RemoveAlignments():
         self.alignments.save()
 
         if self.type == "faces":
-            self.rename_faces()
+            rename = Rename(self.alignments, None, self.items)
+            rename.process()
 
-    def remove_frames(self, item):
+    def remove_frames(self, frame):
         """ Process to remove frames from an alignments file """
-        if item in self.items:
+        if frame in self.items:
+            logger.trace("Not deleting frame: '%s'", frame)
             return 0
-        del self.alignments.data[item]
+        logger.debug("Deleting frame: '%s'", frame)
+        del self.alignments.data[frame]
         return 1
 
-    def remove_faces(self, item):
+    def remove_faces(self):
         """ Process to remove faces from an alignments file """
-        if self.faces_count_matches(item):
+        face_hashes = list(self.items.items.keys())
+        if not face_hashes:
+            logger.error("No face hashes. This would remove all faces from your alignments file.")
             return 0
-        return self.remove_alignment(item)
-
-    def faces_count_matches(self, item):
-        """ Check the selected face exits """
-        frame_name, number_alignments = item[0], item[2]
-        number_faces = len(self.items.items.get(frame_name, list()))
-        return bool(number_alignments in(0, number_faces))
+        pre_face_count = self.alignments.faces_count
+        self.alignments.filter_hashes(face_hashes, filter_out=False)
+        post_face_count = self.alignments.faces_count
+        return pre_face_count - post_face_count
 
     def remove_alignment(self, item):
         """ Remove the alignment from the alignments file """
         del_count = 0
         frame_name, alignments, number_alignments = item[:3]
-        processor = self.alignments.yield_original_index_reverse
-        for idx in processor(alignments, number_alignments):
+        for idx in self.alignments.yield_original_index_reverse(alignments, number_alignments):
             face_indexes = self.items.items.get(frame_name, [-1])
             if idx not in face_indexes:
                 del alignments[idx]
                 self.removed.add(frame_name)
-                logger.verbose("Removed alignment data for image: '%s'"
-                               "index: %s", frame_name, str(idx))
+                logger.verbose("Removed alignment data for image: '%s' index: %s",
+                               frame_name, str(idx))
                 del_count += 1
+            else:
+                logger.trace("Not removing alignment data for image: '%s' index: %s",
+                             frame_name, str(idx))
         return del_count
-
-    def rename_faces(self):
-        """ Rename the aligned faces to match their "
-            new index in alignments file """
-        current_frame = ""
-        current_index = 0
-        rename_count = 0
-        for face in tqdm(self.items.file_list_sorted,
-                         desc="Renaming aligned faces",
-                         total=self.items.count):
-
-            if face["frame_name"] not in self.removed:
-                continue
-            current_index, current_frame = self.set_image_index(
-                current_index,
-                current_frame,
-                face["frame_name"])
-            if current_index != face["face_index"]:
-                rename_count += self.rename_file(face,
-                                                 current_frame,
-                                                 current_index)
-
-            current_index += 1
-        if rename_count == 0:
-            logger.info("No files were renamed. Exiting")
-            return
-        logger.info("%s face(s) were renamed to match with alignments file", rename_count)
-
-    @staticmethod
-    def set_image_index(index, current, original):
-        """ Set the current processing image and index """
-        idx = 0 if current != original else index
-        return idx, original
-
-    def rename_file(self, face, frame_name, index):
-        """ Rename the selected file """
-        old_file = face["face_name"] + face["face_extension"]
-        new_file = "{}_{}{}".format(frame_name,
-                                    str(index),
-                                    face["face_extension"])
-        src = os.path.join(self.items.folder, old_file)
-        dst = os.path.join(self.items.folder, new_file)
-        os.rename(src, dst)
-        logger.verbose("Renamed '%s' to '%s'", src, dst)
-        return 1
 
 
 class Legacy():
@@ -524,35 +521,42 @@ class Legacy():
 
         - Add frame dimensions
         - Rotate landmarks and bounding boxes on legacy alignments
-        and remove the 'r' parameter """
+          and remove the 'r' parameter
+        - Add face hashes to alignments file
+    """
 
-    def __init__(self, alignments, arguments,
-                 frames=None, child_process=False):
+    def __init__(self, alignments, arguments, frames=None, faces=None, child_process=False):
+        logger.debug("Initializing %s: (arguments: %s, child_process: %s)",
+                     self.__class__.__name__, arguments, child_process)
         self.alignments = alignments
-        self.child_process = child_process
-        self.frames = frames
-        if not frames:
+        if child_process:
+            self.frames = frames
+            self.faces = faces
+        else:
             self.frames = Frames(arguments.frames_dir)
+            self.faces = Faces(arguments.faces_dir)
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def process(self):
         """ Run the rotate alignments process """
         no_dims = self.alignments.get_legacy_no_dims()
         rotated = self.alignments.get_legacy_rotation()
-        if self.child_process and not rotated and not no_dims:
+        hashes = self.alignments.get_legacy_no_hashes()
+        if (not self.frames or (not no_dims and not rotated)) and (not self.faces or not hashes):
             return
         logger.info("[UPDATE LEGACY LANDMARKS]")  # Tidy up cli output
-
-        if no_dims:
-            if self.child_process:
-                logger.info("Legacy landmarks found. Adding frame dimensions...")
+        if no_dims and self.frames:
+            logger.info("Legacy landmarks found. Adding frame dimensions...")
             self.add_dimensions(no_dims)
-
-        if rotated:
-            if self.child_process:
-                logger.info("Legacy rotated frames found. Rotating landmarks")
+            self.alignments.save()
+        if rotated and self.frames:
+            logger.info("Legacy rotated frames found. Converting...")
             self.rotate_landmarks(rotated)
-
-        self.alignments.save()
+            self.alignments.save()
+        if hashes and self.faces:
+            logger.info("Legacy alignments found. Adding Face Hashes...")
+            self.add_hashes(hashes)
+            self.alignments.save()
 
     def add_dimensions(self, no_dims):
         """ Add width and height of original frame to alignments """
@@ -569,101 +573,140 @@ class Legacy():
                 continue
             self.alignments.rotate_existing_landmarks(rotate_item)
 
+    def add_hashes(self, hashes):
+        """ Add Face Hashes to the alignments file """
+        all_faces = dict()
+        logger.info("Getting original filenames, indexes and hashes...")
+        for face in self.faces.file_list_sorted:
+            filename = face["face_name"]
+            extension = face["face_extension"]
+            if "_" not in face["face_name"]:
+                logger.warning("Unable to determine index of file. Skipping: '%s'", filename)
+                continue
+            index = filename[filename.rfind("_") + 1:]
+            if not index.isdigit():
+                logger.warning("Unable to determine index of file. Skipping: '%s'", filename)
+                continue
+            orig_frame = filename[:filename.rfind("_")] + extension
+            all_faces.setdefault(orig_frame, dict())[int(index)] = face["face_hash"]
+
+        logger.info("Updating hashes to alignments...")
+        for frame in hashes:
+            if frame not in all_faces.keys():
+                logger.warning("Skipping missing frame: '%s'", frame)
+                continue
+            self.alignments.add_face_hashes(frame, all_faces[frame])
+
+
+class Rename():
+    """ Rename faces to match their source frame and position index """
+    def __init__(self, alignments, arguments, faces=None):
+        logger.debug("Initializing %s: (arguments: %s, faces: %s)",
+                     self.__class__.__name__, arguments, faces)
+        self.alignments = alignments
+        self.faces = faces if faces else Faces(arguments.faces_dir)
+        logger.debug("Initialized %s", self.__class__.__name__)
+
+    def process(self):
+        """ Process the face renaming """
+        logger.info("[RENAME FACES]")  # Tidy up cli output
+        rename_count = 0
+        for frame, _, _, frame_fullname in tqdm(self.alignments.yield_faces(),
+                                                desc="Renaming Faces",
+                                                total=self.alignments.frames_count):
+            rename_count += self.rename_faces(frame, frame_fullname)
+        logger.info("%s faces renamed", rename_count)
+
+    def rename_faces(self, frame, frame_fullname):
+        """ Rename faces
+            Done in 2 iterations as two files cannot share the same name """
+        logger.trace("Renaming faces for frame: '%s'", frame_fullname)
+        temp_ext = ".temp_move"
+        frame_faces = [(f_hash, details[1])
+                       for f_hash, details in self.alignments.hashes_to_frame.items()
+                       if details[0] == frame_fullname]
+        rename_count = 0
+        for f_hash, idx in frame_faces:
+            face_name, face_ext = self.faces.items[f_hash]
+            old = face_name + face_ext
+            new = "{}_{}{}".format(frame, idx, face_ext)
+            if old == new:
+                logger.trace("Face does not require renaming: '%s'", old)
+                continue
+            for action in ("temp", "final"):
+                old_file = old if action == "temp" else old + temp_ext
+                new_file = old + temp_ext if action == "temp" else new
+                src = os.path.join(self.faces.folder, old_file)
+                dst = os.path.join(self.faces.folder, new_file)
+                logger.trace("Renaming: '%s' to '%s'", old_file, new_file)
+                os.rename(src, dst)
+            rename_count += 1
+            logger.verbose("Renamed '%s' to '%s'", old, new)
+        return rename_count
+
 
 class Sort():
     """ Sort alignments' index by the order they appear in
         an image """
     def __init__(self, alignments, arguments):
+        logger.debug("Initializing %s: (arguments: %s)", self.__class__.__name__, arguments)
         self.alignments = alignments
         self.axis = arguments.job.replace("sort-", "")
         self.faces = self.get_faces(arguments)
+        logger.debug("Initialized %s", self.__class__.__name__)
 
-    @staticmethod
-    def get_faces(arguments):
+    def get_faces(self, arguments):
         """ If faces argument is specified, load faces_dir
             otherwise return None """
         if not hasattr(arguments, "faces_dir") or not arguments.faces_dir:
             return None
-        return Faces(arguments.faces_dir)
+        faces = Faces(arguments.faces_dir)
+        legacy = Legacy(self.alignments, None, faces=faces, child_process=True)
+        legacy.process()
+        return faces
 
     def process(self):
         """ Execute the sort process """
         logger.info("[SORT INDEXES]")  # Tidy up cli output
-        self.check_rotated()
-        self.reindex_faces()
-        self.alignments.save()
+        self.check_legacy()
+        reindexed = self.reindex_faces()
+        if reindexed:
+            self.alignments.save()
+        if self.faces:
+            rename = Rename(self.alignments, None, self.faces)
+            rename.process()
 
-    def check_rotated(self):
+    def check_legacy(self):
         """ Legacy rotated alignments will not have the correct x, y
-            positions, so generate a warning and exit """
-        if any(alignment.get("r", None)
-               for val in self.alignments.data.values()
-               for alignment in val):
-            logger.error("There are rotated frames in the alignments "
-                         "file. Position of faces will not be correctly "
-                         "calculated for these frames. You should run rotation "
-                         "tool to update the file prior to running sort: "
-                         "'python tools.py alignments -j rotate -a "
-                         "<alignments_file> -fr <frames_folder>'")
+            positions. Faces without hashes won't process.
+            Check for these and generate a warning and exit """
+        rotated = self.alignments.get_legacy_rotation()
+        hashes = self.alignments.get_legacy_no_hashes()
+        if rotated or hashes:
+            logger.error("Legacy alignments found. Sort cannot continue. You should run legacy "
+                         "tool to update the file prior to running sort: 'python tools.py "
+                         "alignments -j legacy -a <alignments_file> -fr <frames_folder> -fc "
+                         "<faces_folder>'")
             exit(0)
 
     def reindex_faces(self):
         """ Re-Index the faces """
         reindexed = 0
         for alignment in tqdm(self.alignments.yield_faces(),
-                              desc="Sort alignment indexes",
-                              total=self.alignments.frames_count):
+                              desc="Sort alignment indexes", total=self.alignments.frames_count):
             frame, alignments, count, key = alignment
             if count <= 1:
+                logger.trace("0 or 1 face in frame. Not sorting: '%s'", frame)
                 continue
-            sorted_alignments = sorted([item for item in alignments],
-                                       key=lambda x: (x[self.axis]))
+            sorted_alignments = sorted([item for item in alignments], key=lambda x: (x[self.axis]))
             if sorted_alignments == alignments:
+                logger.trace("Alignments already in correct order. Not sorting: '%s'", frame)
                 continue
-            map_faces = self.map_face_names(alignments,
-                                            sorted_alignments,
-                                            frame)
-            self.rename_faces(map_faces)
+            logger.trace("Sorting alignments for frame: '%s'", frame)
             self.alignments.data[key] = sorted_alignments
             reindexed += 1
         logger.info("%s Frames had their faces reindexed", reindexed)
-
-    def map_face_names(self, alignments, sorted_alignments, frame):
-        """ Map the old and new indexes for face renaming """
-        map_faces = list()
-        if not self.faces:
-            return map_faces
-        for idx, alignment in enumerate(alignments):
-            idx_new = sorted_alignments.index(alignment)
-            mapping = [{"old_name": face["face_fullname"],
-                        "new_name": "{}_{}{}".format(frame,
-                                                     idx_new,
-                                                     face["face_extension"])}
-                       for face in self.faces.file_list_sorted
-                       if face["frame_name"] == frame
-                       and face["face_index"] == idx]
-            if not mapping:
-                logger.warning("No face image found for frame '%s' at index %s", frame, idx)
-            map_faces.extend(mapping)
-        return map_faces
-
-    def rename_faces(self, map_faces):
-        """ Rename faces
-            Done in 2 iterations as two files cannot share the same name """
-        temp_ext = ".temp_move"
-        for action in ("temp", "final"):
-            for face in map_faces:
-                old = face["old_name"]
-                new = face["new_name"]
-                if old == new:
-                    continue
-                old_file = old if action == "temp" else old + temp_ext
-                new_file = old + temp_ext if action == "temp" else new
-                src = os.path.join(self.faces.folder, old_file)
-                dst = os.path.join(self.faces.folder, new_file)
-                os.rename(src, dst)
-                if action == "final":
-                    logger.verbose("Renamed '%s' to '%s'", old, new)
+        return reindexed
 
 
 class Spatial():
@@ -672,11 +715,13 @@ class Spatial():
         https://www.kaggle.com/selfishgene/animating-and-smoothing-3d-facial-keypoints/notebook """
 
     def __init__(self, alignments, arguments):
+        logger.debug("Initializing %s: (arguments: %s)", self.__class__.__name__, arguments)
         self.arguments = arguments
         self.alignments = alignments
         self.mappings = dict()
         self.normalized = dict()
         self.shapes_model = None
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def process(self):
         """ Perform spatial filtering """
@@ -701,44 +746,45 @@ class Spatial():
     @staticmethod
     def normalize_shapes(shapes_im_coords):
         """ Normalize a 2D or 3D shape """
+        logger.debug("Normalize shapes")
         (num_pts, num_dims, _) = shapes_im_coords.shape
 
         # calc mean coords and subtract from shapes
         mean_coords = shapes_im_coords.mean(axis=0)
         shapes_centered = np.zeros(shapes_im_coords.shape)
-        shapes_centered = shapes_im_coords - np.tile(mean_coords,
-                                                     [num_pts, 1, 1])
+        shapes_centered = shapes_im_coords - np.tile(mean_coords, [num_pts, 1, 1])
 
         # calc scale factors and divide shapes
         scale_factors = np.sqrt((shapes_centered**2).sum(axis=1)).mean(axis=0)
         shapes_normalized = np.zeros(shapes_centered.shape)
-        shapes_normalized = shapes_centered / np.tile(scale_factors,
-                                                      [num_pts, num_dims, 1])
+        shapes_normalized = shapes_centered / np.tile(scale_factors, [num_pts, num_dims, 1])
 
+        logger.debug("Normalized shapes: (shapes_normalized: %s, scale_factors: %s, mean_coords: "
+                     "%s", shapes_normalized, scale_factors, mean_coords)
         return shapes_normalized, scale_factors, mean_coords
 
     @staticmethod
     def normalized_to_original(shapes_normalized, scale_factors, mean_coords):
         """ Transform a normalized shape back to original image coordinates """
+        logger.debug("Normalize to original")
         (num_pts, num_dims, _) = shapes_normalized.shape
 
         # move back to the correct scale
-        shapes_centered = shapes_normalized * np.tile(scale_factors,
-                                                      [num_pts, num_dims, 1])
+        shapes_centered = shapes_normalized * np.tile(scale_factors, [num_pts, num_dims, 1])
         # move back to the correct location
-        shapes_im_coords = shapes_centered + np.tile(mean_coords,
-                                                     [num_pts, 1, 1])
+        shapes_im_coords = shapes_centered + np.tile(mean_coords, [num_pts, 1, 1])
 
+        logger.debug("Normalized to original: %s", shapes_im_coords)
         return shapes_im_coords
 
     def normalize(self):
         """ Compile all original and normalized alignments """
+        logger.debug("Normalize")
         count = sum(1 for val in self.alignments.data.values() if val)
         landmarks_all = np.zeros((68, 2, int(count)))
 
         end = 0
-        for key in tqdm(sorted(self.alignments.data.keys()),
-                        desc="Compiling"):
+        for key in tqdm(sorted(self.alignments.data.keys()), desc="Compiling"):
             val = self.alignments.data[key]
             if not val:
                 continue
@@ -757,28 +803,29 @@ class Spatial():
         self.normalized["landmarks"] = normalized_shape[0]
         self.normalized["scale_factors"] = normalized_shape[1]
         self.normalized["mean_coords"] = normalized_shape[2]
+        logger.debug("Normalized: %s", self.normalized)
 
     def shape_model(self):
         """ build 2D shape model """
+        logger.debug("Shape model")
         landmarks_norm = self.normalized["landmarks"]
         num_components = 20
-        normalized_shapes_tbl = np.reshape(landmarks_norm,
-                                           [68*2, landmarks_norm.shape[2]]).T
-        self.shapes_model = decomposition.PCA(
-            n_components=num_components,
-            whiten=True,
-            random_state=1).fit(normalized_shapes_tbl)
+        normalized_shapes_tbl = np.reshape(landmarks_norm, [68*2, landmarks_norm.shape[2]]).T
+        self.shapes_model = decomposition.PCA(n_components=num_components,
+                                              whiten=True,
+                                              random_state=1).fit(normalized_shapes_tbl)
         explained = self.shapes_model.explained_variance_ratio_.sum()
         logger.info("Total explained percent by PCA model with %s components is %s%%",
                     num_components, round(100 * explained, 1))
+        logger.debug("Shaped model")
 
     def spatially_filter(self):
         """ interpret the shapes using our shape model
             (project and reconstruct) """
+        logger.debug("Spatially Filter")
         landmarks_norm = self.normalized["landmarks"]
         # convert to matrix form
-        landmarks_norm_table = np.reshape(landmarks_norm,
-                                          [68 * 2, landmarks_norm.shape[2]]).T
+        landmarks_norm_table = np.reshape(landmarks_norm, [68 * 2, landmarks_norm.shape[2]]).T
         # project onto shapes model and reconstruct
         landmarks_norm_table_rec = self.shapes_model.inverse_transform(
             self.shapes_model.transform(landmarks_norm_table))
@@ -786,30 +833,36 @@ class Spatial():
         landmarks_norm_rec = np.reshape(landmarks_norm_table_rec.T,
                                         [68, 2, landmarks_norm.shape[2]])
         # transform back to image coords
-        return self.normalized_to_original(landmarks_norm_rec,
-                                           self.normalized["scale_factors"],
-                                           self.normalized["mean_coords"])
+        retval = self.normalized_to_original(landmarks_norm_rec,
+                                             self.normalized["scale_factors"],
+                                             self.normalized["mean_coords"])
+
+        logger.debug("Spatially Filtered: %s", retval)
+        return retval
 
     @staticmethod
     def temporally_smooth(landmarks):
         """ apply temporal filtering on the 2D points """
+        logger.debug("Temporally Smooth")
         filter_half_length = 2
-        temporal_filter = np.ones((1, 1, 2*filter_half_length+1))
+        temporal_filter = np.ones((1, 1, 2 * filter_half_length + 1))
         temporal_filter = temporal_filter / temporal_filter.sum()
 
-        start_tileblock = np.tile(landmarks[:, :, 0][:, :, np.newaxis],
-                                  [1, 1, filter_half_length])
-        end_tileblock = np.tile(landmarks[:, :, -1][:, :, np.newaxis],
-                                [1, 1, filter_half_length])
-        landmarks_padded = np.dstack((start_tileblock,
-                                      landmarks,
-                                      end_tileblock))
-        return signal.convolve(landmarks_padded, temporal_filter,
-                               mode='valid', method='fft')
+        start_tileblock = np.tile(landmarks[:, :, 0][:, :, np.newaxis], [1, 1, filter_half_length])
+        end_tileblock = np.tile(landmarks[:, :, -1][:, :, np.newaxis], [1, 1, filter_half_length])
+        landmarks_padded = np.dstack((start_tileblock, landmarks, end_tileblock))
+
+        retval = signal.convolve(landmarks_padded, temporal_filter, mode='valid', method='fft')
+        logger.debug("Temporally Smoothed: %s", retval)
+        return retval
 
     def update_alignments(self, landmarks):
         """ Update smoothed landmarks back to alignments """
+        logger.debug("Update alignments")
         for idx, frame in tqdm(self.mappings.items(), desc="Updating"):
+            logger.trace("Updating: (frame: %s)", frame)
             landmarks_update = landmarks[:, :, idx].astype(int)
             landmarks_xy = landmarks_update.reshape(68, 2).tolist()
             self.alignments.data[frame][0]["landmarksXY"] = landmarks_xy
+            logger.trace("Updated: (frame: '%s', landmarks: %s)", frame, landmarks_xy)
+        logger.debug("Updated alignments")

--- a/tools/lib_alignments/media.py
+++ b/tools/lib_alignments/media.py
@@ -4,12 +4,13 @@
 
 import logging
 import os
+from tqdm import tqdm
 
 import cv2
 
 from lib.alignments import Alignments
 from lib.faces_detect import DetectedFace
-from lib.utils import _image_extensions
+from lib.utils import _image_extensions, hash_image_file, hash_encode_image
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -18,14 +19,17 @@ class AlignmentData(Alignments):
     """ Class to hold the alignment data """
 
     def __init__(self, alignments_file, destination_format):
+        logger.debug("Initializing %s: (alignments file: '%s', destination_format: '%s')",
+                     self.__class__.__name__, alignments_file, destination_format)
         logger.info("[ALIGNMENT DATA]")  # Tidy up cli output
         folder, filename = self.check_file_exists(alignments_file)
-        if filename == "dfl":
+        if filename.lower() == "dfl":
             self.set_dfl(destination_format)
             return
         super().__init__(folder, filename=filename)
         self.set_destination_format(destination_format)
         logger.verbose("%s items loaded", self.frames_count)
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     @staticmethod
     def check_file_exists(alignments_file):
@@ -44,6 +48,7 @@ class AlignmentData(Alignments):
 
     def set_dfl(self, destination_format):
         """ Set the alignments for dfl alignments """
+        logger.debug("Alignments are DFL format")
         self.file = "dfl"
         self.set_destination_format(destination_format)
 
@@ -55,6 +60,7 @@ class AlignmentData(Alignments):
                       ".yaml": "yaml"}
         dst_fmt = None
         file_ext = os.path.splitext(self.file)[1].lower()
+        logger.debug("File extension: '%s'", file_ext)
 
         if destination_format is not None:
             dst_fmt = destination_format
@@ -71,6 +77,7 @@ class AlignmentData(Alignments):
         self.serializer = self.get_serializer("", dst_fmt)
         filename = os.path.splitext(self.file)[0]
         self.file = "{}.{}".format(filename, self.serializer.ext)
+        logger.debug("Destination file: '%s'", self.file)
 
     def save(self):
         """ Backup copy of old alignments and save new alignments """
@@ -81,6 +88,7 @@ class AlignmentData(Alignments):
 class MediaLoader():
     """ Class to load filenames from folder """
     def __init__(self, folder):
+        logger.debug("Initializing %s: (folder: '%s')", self.__class__.__name__, folder)
         logger.info("[%s DATA]", self.__class__.__name__.upper())
         self.folder = folder
         self.check_folder_exists()
@@ -88,6 +96,7 @@ class MediaLoader():
         self.items = self.load_items()
         self.count = len(self.file_list_sorted)
         logger.verbose("%s items loaded", self.count)
+        logger.debug("Initialized %s", self.__class__.__name__)
 
     def check_folder_exists(self):
         """ makes sure that the faces folder exists """
@@ -108,7 +117,9 @@ class MediaLoader():
     def valid_extension(filename):
         """ Check whether passed in file has a valid extension """
         extension = os.path.splitext(filename)[1]
-        return bool(extension in _image_extensions)
+        retval = extension in _image_extensions
+        logger.trace("Filename has valid extension: '%s': %s", filename, retval)
+        return retval
 
     @staticmethod
     def sorted_items():
@@ -128,6 +139,7 @@ class MediaLoader():
     def load_image(self, filename):
         """ Load an image """
         src = os.path.join(self.folder, filename)
+        logger.trace("Loading image: '%s'", src)
         image = cv2.imread(src)  # pylint: disable=no-member
         return image
 
@@ -135,46 +147,42 @@ class MediaLoader():
     def save_image(output_folder, filename, image):
         """ Save an image """
         output_file = os.path.join(output_folder, filename)
+        logger.trace("Saving image: '%s'", output_file)
         cv2.imwrite(output_file, image)  # pylint: disable=no-member
 
 
 class Faces(MediaLoader):
     """ Object to hold the faces that are to be swapped out """
-    def __init__(self, folder, dfl=False):
-        self.dfl = dfl
-        super().__init__(folder)
 
     def process_folder(self):
         """ Iterate through the faces dir pulling out various information """
         logger.info("Loading file list from %s", self.folder)
-        for face in os.listdir(self.folder):
+        for face in tqdm(os.listdir(self.folder), desc="Reading Face Hashes"):
             if not self.valid_extension(face):
                 continue
             filename = os.path.splitext(face)[0]
             file_extension = os.path.splitext(face)[1]
-            index = 0
-            original_file = ""
-            if not self.dfl:
-                index = int(filename[filename.rindex("_") + 1:])
-                original_file = "{}".format(filename[:filename.rindex("_")])
-            yield {"face_fullname": face,
-                   "face_name": filename,
-                   "face_extension": file_extension,
-                   "frame_name": original_file,
-                   "face_index": index}
+            face_hash = hash_image_file(os.path.join(self.folder, face))
+            retval = {"face_fullname": face,
+                      "face_name": filename,
+                      "face_extension": file_extension,
+                      "face_hash": face_hash}
+            logger.trace(retval)
+            yield retval
 
     def load_items(self):
         """ Load the face names into dictionary """
-        faces = dict()
-        for face in self.file_list_sorted:
-            faces.setdefault(face["frame_name"],
-                             list()).append(face["face_index"])
+        faces = {face["face_hash"]: (face["face_name"], face["face_extension"])
+                 for face in self.file_list_sorted}
+        logger.trace(faces)
         return faces
 
     def sorted_items(self):
-        """ Return the items sorted by filename then index """
-        return sorted([item for item in self.process_folder()],
-                      key=lambda x: (x["frame_name"], x["face_index"]))
+        """ Return the items sorted by face name """
+        items = sorted([item for item in self.process_folder()],
+                       key=lambda x: (x["face_name"]))
+        logger.trace(items)
+        return items
 
 
 class Frames(MediaLoader):
@@ -189,9 +197,11 @@ class Frames(MediaLoader):
             filename = os.path.splitext(frame)[0]
             file_extension = os.path.splitext(frame)[1]
 
-            yield {"frame_fullname": frame,
-                   "frame_name": filename,
-                   "frame_extension": file_extension}
+            retval = {"frame_fullname": frame,
+                      "frame_name": filename,
+                      "frame_extension": file_extension}
+            logger.trace(retval)
+            yield retval
 
     def load_items(self):
         """ Load the frame info into dictionary """
@@ -199,12 +209,15 @@ class Frames(MediaLoader):
         for frame in self.file_list_sorted:
             frames[frame["frame_fullname"]] = (frame["frame_name"],
                                                frame["frame_extension"])
+        logger.trace(frames)
         return frames
 
     def sorted_items(self):
         """ Return the items sorted by filename """
-        return sorted([item for item in self.process_folder()],
-                      key=lambda x: (x["frame_name"]))
+        items = sorted([item for item in self.process_folder()],
+                       key=lambda x: (x["frame_name"]))
+        logger.trace(items)
+        return items
 
 
 class ExtractedFaces():
@@ -212,6 +225,8 @@ class ExtractedFaces():
         alignments """
     def __init__(self, frames, alignments, size=256,
                  padding=48, align_eyes=False):
+        logger.trace("Initializing %s: (size: %s, padding: %s, align_eyes: %s)",
+                     self.__class__.__name__, size, padding, align_eyes)
         self.size = size
         self.padding = padding
         self.align_eyes = align_eyes
@@ -220,12 +235,15 @@ class ExtractedFaces():
 
         self.current_frame = None
         self.faces = list()
+        logger.trace("Initialized %s", self.__class__.__name__)
 
     def get_faces(self, frame):
         """ Return faces and transformed landmarks
             for each face in a given frame with it's alignments"""
+        logger.trace("Getting faces for frame: '%s'", frame)
         self.current_frame = None
         alignments = self.alignments.get_faces_in_frame(frame)
+        logger.trace("Alignments for frame: (frame: '%s', alignments: %s)", frame, alignments)
         if not alignments:
             self.faces = list()
             return
@@ -236,6 +254,8 @@ class ExtractedFaces():
 
     def extract_one_face(self, alignment, image):
         """ Extract one face from image """
+        logger.trace("Extracting one face: (frame: '%s', alignment: %s)",
+                     self.current_frame, alignment)
         face = DetectedFace()
         face.from_alignment(alignment, image=image)
         face.load_aligned(image,
@@ -246,6 +266,7 @@ class ExtractedFaces():
 
     def get_faces_in_frame(self, frame, update=False):
         """ Return the faces for the selected frame """
+        logger.trace("frame: '%s', update: %s", frame, update)
         if self.current_frame != frame or update:
             self.get_faces(frame)
         return self.faces
@@ -253,6 +274,7 @@ class ExtractedFaces():
     def get_roi_size_for_frame(self, frame):
         """ Return the size of the original extract box for
             the selected frame """
+        logger.trace("frame: '%s'", frame)
         if self.current_frame != frame:
             self.get_faces(frame)
         sizes = list()
@@ -265,4 +287,14 @@ class ExtractedFaces():
             else:
                 length = int(((len_x ** 2) + (len_y ** 2)) ** 0.5)
             sizes.append(length)
+        logger.trace("sizes: '%s'", sizes)
         return sizes
+
+    @staticmethod
+    def save_face_with_hash(filename, extension, face):
+        """ Save a face and return it's hash """
+        f_hash, img = hash_encode_image(face, extension)
+        logger.trace("Saving face: '%s'", filename)
+        with open(filename, "wb") as out_file:
+            out_file.write(img)
+        return f_hash


### PR DESCRIPTION
This PR adds Face Hashes to the Alignments file.

There is no perfect solution to the handling of faces. The current index based system has numerous drawbacks, most notably that changing the filename of an extracted face means that it is no longer discoverable by the Faceswap process, adding needless complexity.

By hashing the image of the extracted face, the filename can be changed (e.g. by the Sort Tool), and the face will still be found. The drawback is that any post-processing done on extracted faces will alter the hash and render the file undiscoverable again, however tools will be added to the alignments tool to mitigate this.

Other advantages include making it easier to merge alignments, and offering a better solution for future models that require access to the alignments file.

Currently:
Main scripts updated to use hashes (extract and convert).
Alignment tool has been updated to use hashes
Legacy alignments will automatically be converted
Rename function added to alignment tool to enable renaming alignments to correspond with their parent frame and index