### PR TITLE
Catch pynvml.NVMLError_DriverNotLoaded Exception in gpu_stats

### DIFF
--- a/lib/gpu_stats.py
+++ b/lib/gpu_stats.py
@@ -32,6 +32,8 @@ class GPUStats():
         self.initialize()
 
         if self.device_count == 0:
+            if self.logger:
+                self.logger.warning("No GPU detected. Switching to CPU mode")
             return
 
         self.driver = self.get_driver()
@@ -59,8 +61,6 @@ class GPUStats():
                         self.logger.debug("OS is not macOS. Using pynvml")
                     pynvml.nvmlInit()
                 except (pynvml.NVMLError_LibraryNotFound, pynvml.NVMLError_DriverNotLoaded):
-                    if self.logger:
-                        self.logger.warning("No GPU detected. Switching to CPU mode")
                     self.initialized = True
                     return
             self.initialized = True

--- a/lib/gpu_stats.py
+++ b/lib/gpu_stats.py
@@ -59,6 +59,8 @@ class GPUStats():
                         self.logger.debug("OS is not macOS. Using pynvml")
                     pynvml.nvmlInit()
                 except (pynvml.NVMLError_LibraryNotFound, pynvml.NVMLError_DriverNotLoaded):
+                    if self.logger:
+                        self.logger.warning("No GPU detected. Switching to CPU mode")
                     self.initialized = True
                     return
             self.initialized = True

--- a/lib/gpu_stats.py
+++ b/lib/gpu_stats.py
@@ -58,7 +58,7 @@ class GPUStats():
                     if self.logger:
                         self.logger.debug("OS is not macOS. Using pynvml")
                     pynvml.nvmlInit()
-                except pynvml.NVMLError_LibraryNotFound:
+                except (pynvml.NVMLError_LibraryNotFound, pynvml.NVMLError_DriverNotLoaded):
                     self.initialized = True
                     return
             self.initialized = True


### PR DESCRIPTION
When trying to run under Manjaro i get:

```
Traceback (most recent call last):
  File "faceswap.py", line 5, in <module>
    import lib.cli as cli
  File "/run/media/nope/data/home/nope/workspace/fswap/faceswap/lib/cli.py", line 11, in <module>
    from lib.logger import crash_log, log_setup
  File "/run/media/nope/data/home/nope/workspace/fswap/faceswap/lib/logger.py", line 15, in <module>
    from lib.sysinfo import sysinfo
  File "/run/media/nope/data/home/nope/workspace/fswap/faceswap/lib/sysinfo.py", line 283, in <module>
    sysinfo = SysInfo()  # pylint: disable=invalid-name
  File "/run/media/nope/data/home/nope/workspace/fswap/faceswap/lib/sysinfo.py", line 19, in __init__
    gpu_stats = GPUStats(log=False)
  File "/run/media/nope/data/home/nope/workspace/fswap/faceswap/lib/gpu_stats.py", line 32, in __init__
    self.initialize()
  File "/run/media/nope/data/home/nope/workspace/fswap/faceswap/lib/gpu_stats.py", line 60, in initialize
    pynvml.nvmlInit()
  File "/usr/lib/python3.7/site-packages/pynvml.py", line 615, in nvmlInit
    _nvmlCheckReturn(ret)
  File "/usr/lib/python3.7/site-packages/pynvml.py", line 310, in _nvmlCheckReturn
    raise NVMLError(ret)
pynvml.NVMLError_DriverNotLoaded: Driver Not Loaded

```

Under Debian a non existent Nvidia card raised `NVMLError_LibraryNotFound` which is caught in `GPU_stats.initialize` and switched to CPU mode (A printed warning at that point would probably nice for misconfigured systems.)

On Manjaro this seem to raise a pynvml.NVMLError_DriverNotLoaded exception which this mini PR now also catches.