### PR TITLE
Add ability to extract from and convert from a video file

### DIFF
--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -28,7 +28,7 @@ class Extract():
         self.output_dir = get_folder(self.args.output_dir)
         logger.info("Output Directory: %s", self.args.output_dir)
         self.images = Images(self.args)
-        self.alignments = Alignments(self.args, True)
+        self.alignments = Alignments(self.args, True, self.images.is_video)
         self.plugins = Plugins(self.args)
 
         self.post_process = PostProcess(arguments)


### PR DESCRIPTION
This PR adds the ability to extract directly from a video file.

To use: point the `-i` flag at a video rather than a folder. A video file can be used as source in both extract and convert.

Convert to video will come when convert is refactored.

The GUI will be amended to allow selection of a video file. In the meantime, select the folder that the video file resides in, and manually append the video name to the created path.

Alignments files created using videos are named `<video_filename>_alignments.json>` so that multiple videos in the same folder will not overwrite an existing alignments file. If selecting a video at convert, the alignments file will automatically be picked up with this naming convention.

TODO:
- Update Cli
- Add ability to select video file from GUI