### PR TITLE
detection bugfixes:

### DIFF
--- a/plugins/extract/align/fan.py
+++ b/plugins/extract/align/fan.py
@@ -60,10 +60,10 @@ class Align(Aligner):
                 break
             image = item["image"][:, :, ::-1].copy()
 
-            logger.trace("Algning faces")
+            logger.trace("Aligning faces")
             try:
                 item["landmarks"] = self.process_landmarks(image, item["detected_faces"])
-                logger.trace("Algned faces: %s", item["landmarks"])
+                logger.trace("Aligned faces: %s", item["landmarks"])
             except ValueError as err:
                 logger.warning("Image '%s' could not be processed. This may be due to corrupted "
                                "data: %s", item["filename"], str(err))

--- a/plugins/extract/detect/dlib_hog.py
+++ b/plugins/extract/detect/dlib_hog.py
@@ -37,7 +37,7 @@ class Detect(Detector):
             if item == "EOF":
                 break
             logger.trace("Detecting faces: %s", item["filename"])
-            detect_image = self.compile_detection_image(item["image"], True, True)
+            [detect_image, scale] = self.compile_detection_image(item["image"], True, True)
 
             for angle in self.rotation:
                 current_image, rotmat = self.rotate_image(detect_image, angle)
@@ -52,7 +52,7 @@ class Detect(Detector):
                 if faces:
                     break
 
-            detected_faces = self.process_output(faces, rotmat)
+            detected_faces = self.process_output(faces, rotmat, scale)
             item["detected_faces"] = detected_faces
             self.finalize(item)
 
@@ -61,7 +61,7 @@ class Detect(Detector):
             self.queues["out"].put("EOF")
         logger.debug("Detecting Faces Complete")
 
-    def process_output(self, faces, rotation_matrix):
+    def process_output(self, faces, rotation_matrix, scale):
         """ Compile found faces for output """
         logger.trace("Processing Output: (faces: %s, rotation_matrix: %s)",
                      faces, rotation_matrix)
@@ -69,8 +69,8 @@ class Detect(Detector):
             faces = [self.rotate_rect(face, rotation_matrix)
                      for face in faces]
         detected = [dlib.rectangle(  # pylint: disable=c-extension-no-member
-            int(face.left() / self.scale), int(face.top() / self.scale),
-            int(face.right() / self.scale), int(face.bottom() / self.scale))
+            int(face.left() / scale), int(face.top() / scale),
+            int(face.right() / scale), int(face.bottom() / scale))
                     for face in faces]
         logger.trace("Processed Output: %s", detected)
         return detected

--- a/plugins/extract/detect/mtcnn.py
+++ b/plugins/extract/detect/mtcnn.py
@@ -136,7 +136,7 @@ class Detect(Detector):
             if item == "EOF":
                 break
             logger.trace("Detecting faces: '%s'", item["filename"])
-            detect_image = self.compile_detection_image(item["image"], False, False)
+            [detect_image, scale] = self.compile_detection_image(item["image"], False, False)
 
             for angle in self.rotation:
                 current_image, rotmat = self.rotate_image(detect_image, angle)
@@ -146,13 +146,13 @@ class Detect(Detector):
                 if faces.any():
                     break
 
-            detected_faces = self.process_output(faces, points, rotmat)
+            detected_faces = self.process_output(faces, points, rotmat, scale)
             item["detected_faces"] = detected_faces
             self.finalize(item)
 
         logger.debug("Thread Completed Detect")
 
-    def process_output(self, faces, points, rotation_matrix):
+    def process_output(self, faces, points, rotation_matrix, scale):
         """ Compile found faces for output """
         logger.trace("Processing Output: (faces: %s, points: %s, rotation_matrix: %s)",
                      faces, points, rotation_matrix)
@@ -164,10 +164,10 @@ class Detect(Detector):
             faces = [self.rotate_rect(face, rotation_matrix)
                      for face in faces]
         detected = [dlib.rectangle(  # pylint: disable=c-extension-no-member
-            int(face.left() / self.scale),
-            int(face.top() / self.scale),
-            int(face.right() / self.scale),
-            int(face.bottom() / self.scale))
+            int(face.left() / scale),
+            int(face.top() / scale),
+            int(face.right() / scale),
+            int(face.bottom() / scale))
                     for face in faces]
         logger.trace("Processed Output: %s", detected)
         return detected


### PR DESCRIPTION
-scale in detector has been used as a member variable and shared between multiple threads. however scale heavily depends on the concrete image. if thread change occurs between calculation of scale, actual detection and postprocessing, then random behaviour and exceptions might happen. especially in the case of input images with varying sizes this might cause negative effects

-wrong scale factor calculation:
scale factor was calculated as: scale = target / source
whereas target and source are variables for the total number of pixels in the image (= width * height)
However, later on it was applied on the individual dimensions/components as width/height independantly:
e.g.: dims = (int(width * scale), int(height * scale))
or: int(face.left() / scale),

therefore scaling factor often was too small and detection for very big input images was performed on very small intermediate images
Therefore calculation has been changed to:
scale = sqrt(target / source)