### PR TITLE
Fixed GPU memory allocation issues.

### DIFF
--- a/plugins/model/Model_Original/Model.py
+++ b/plugins/model/Model_Original/Model.py
@@ -1,4 +1,11 @@
 # Based on the original https://www.reddit.com/r/deepfakes/ code sample + contribs
+#For GPU memory allocation issues
+import tensorflow as tf
+from keras.backend.tensorflow_backend import set_session
+config = tf.ConfigProto()
+config.gpu_options.allow_growth = True
+config.gpu_options.visible_device_list = "0"
+set_session(tf.Session(config=config))
 
 from keras.models import Model as KerasModel
 from keras.layers import Input, Dense, Flatten, Reshape


### PR DESCRIPTION
This edit fixes the GPU memory allocation issues. The solution is described here https://www.tensorflow.org/guide/using_gpu. The same thing is done when running train.py with the "--allow-growth" flag. This solution has only been tested with a single GPU. 
RTX 2060, Cuda 10.0, 4.15 driver, cudnn 7.4, tensorflow 1.13rc