### PR TITLE
Rounding error fix

### DIFF
--- a/plugins/convert/masked.py
+++ b/plugins/convert/masked.py
@@ -33,6 +33,7 @@ class Convert():
         image = image.astype('float32')
         image_size = (image.shape[1], image.shape[0])
         coverage = int(self.training_coverage_ratio * self.training_size)
+        coverage = coverage // 2 * 2 # this performs a floor rounding to the next multiple of 2
         padding = (self.training_size - coverage) // 2
         logger.trace("coverage: %s, padding: %s", coverage, padding)
 

--- a/plugins/train/trainer/_base.py
+++ b/plugins/train/trainer/_base.py
@@ -368,6 +368,7 @@ class Samples():
         images = [faces] + predictions
         full_size = full.shape[1]
         target_size = int(full_size * self.coverage_ratio)
+        target_size = target_size // 2 * 2  # this performs a floor rounding to the next multiple of 2
         if target_size != full_size:
             frame = self.frame_overlay(full, target_size, (0, 0, 255))
 


### PR DESCRIPTION
Had the following error when trying to convert some images using villain model and a coverage ratio of 67% (lowmen + dfl-mask):
Traceback (most recent call last):
  File "c:\faceswap_exp\lib\cli.py", line 90, in execute_script
    process.process()
  File "c:\faceswap_exp\scripts\convert.py", line 60, in process
    self.convert(converter, item)
  File "c:\faceswap_exp\scripts\convert.py", line 189, in convert
    image = converter.patch_image(image, face)
  File "c:\faceswap_exp\plugins\convert\masked.py", line 45, in patch_image
    new_image = self.get_new_image(image, detected_face, coverage, image_size)
  File "c:\faceswap_exp\plugins\convert\masked.py", line 81, in get_new_image
    src_face[self.crop, self.crop] = new_face
ValueError: could not broadcast input array from shape (171,171,3) into shape (172,172,3)

Obviously a bug related to some rounding error caused by coverage ratio.
Other ratios as e.g. 66% worked.

Had a look at training_data.py and here the range was calculated like that:
coverage = int(image.shape[0] * self.coverage_ratio)
...
range_ = np.linspace(height // 2 - coverage // 2,
                             height // 2 + coverage // 2,
                             5, dtype='float32')

for 128px that means:
coverage = int(128 * 0.67) = int(85,76) = 85
range_ = np.linspace(128 // 2 - 85 // 2,
                               128 // 2 + 85 // 2)
            = np.linspace(64 - 42,
                                   64 + 42)

thus, the remaining image is only 42*2 = 84 px height because integer rounding (floor) has been performed on top and on bottom individually and result will be always the next integer that is dividible by 2.

however, then looking at convert:

coverage = int(self.training_coverage_ratio * self.training_size)
padding = (self.training_size - coverage) // 2

coverage will be 85 and padding will be (128-85) // 2 = 21

reducing the image by the padding on each side, then the remaining image is now 128-2x21 = 86 px.
Thus we got a discrepancy.

To solve this, I added the line:
coverage = coverage // 2 * 2
in masked.py

Conversion at least succeded but it would be nice if someone else could have a look at this.