### PR TITLE
Fix -dt by starting with a 4 channel mask already in place.

### DIFF
--- a/plugins/convert/masked.py
+++ b/plugins/convert/masked.py
@@ -43,8 +43,14 @@ class Convert():
         detected_face.load_aligned(image, size=self.training_size, align_eyes=False)
         new_image = self.get_new_image(image, detected_face, coverage, image_size)
         image_mask = self.get_image_mask(detected_face, image_size)
+
         if self.args.draw_transparent:
-            new_image = dfl_full(detected_face.landmarks_as_xy, new_image, channels=4)
+            new_image = dfl_full(detected_face.landmarks_as_xy, new_image, channels=4 #Add mask as 4th channel for saving as alpha on supported output formats
+
+            #This make sure that all the arrays match in size for later actions despite not actually using alpha in any way.
+            image_mask = cv2.cvtColor(image_mask, cv2.COLOR_RGB2RGBA)
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA)
+
         patched_face = self.apply_fixes(image,
                                         new_image,
                                         image_mask,
@@ -151,12 +157,6 @@ class Convert():
 
     def apply_fixes(self, frame, new_image, image_mask, image_size):
         """ Apply fixes """
-        masked = new_image  # * image_mask
-
-        if self.args.draw_transparent:
-            alpha = np.full((image_size[1], image_size[0], 1), 255.0, dtype='float32')
-            image_mask = cv2.cvtColor(image_mask, cv2.COLOR_RGB2RGBA)
-            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA)
 
         if self.args.sharpen_image is not None and self.args.sharpen_image.lower() != "none":
             np.clip(new_image, 0.0, 255.0, out=new_image)

--- a/plugins/convert/masked.py
+++ b/plugins/convert/masked.py
@@ -45,11 +45,11 @@ class Convert():
         image_mask = self.get_image_mask(detected_face, image_size)
 
         if self.args.draw_transparent:
-            new_image = dfl_full(detected_face.landmarks_as_xy, new_image, channels=4 #Add mask as 4th channel for saving as alpha on supported output formats
+            new_image = dfl_full(detected_face.landmarks_as_xy, new_image, channels=4 )#Add mask as 4th channel for saving as alpha on supported output formats
 
             #This make sure that all the arrays match in size for later actions despite not actually using alpha in any way.
             image_mask = cv2.cvtColor(image_mask, cv2.COLOR_RGB2RGBA)
-            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA)
+            image = cv2.cvtColor(image, cv2.COLOR_RGB2RGBA)
 
         patched_face = self.apply_fixes(image,
                                         new_image,

--- a/plugins/convert/masked.py
+++ b/plugins/convert/masked.py
@@ -43,6 +43,8 @@ class Convert():
         detected_face.load_aligned(image, size=self.training_size, align_eyes=False)
         new_image = self.get_new_image(image, detected_face, coverage, image_size)
         image_mask = self.get_image_mask(detected_face, image_size)
+        if self.args.draw_transparent:
+            new_image = dfl_full(detected_face.landmarks_as_xy, new_image, channels=4)
         patched_face = self.apply_fixes(image,
                                         new_image,
                                         image_mask,
@@ -149,12 +151,12 @@ class Convert():
 
     def apply_fixes(self, frame, new_image, image_mask, image_size):
         """ Apply fixes """
+        masked = new_image  # * image_mask
 
         if self.args.draw_transparent:
             alpha = np.full((image_size[1], image_size[0], 1), 255.0, dtype='float32')
-            new_image = np.concatenate(new_image, alpha, axis=2)
-            image_mask = np.concatenate(image_mask, alpha, axis=2)
-            frame = np.concatenate(frame, alpha, axis=2)
+            image_mask = cv2.cvtColor(image_mask, cv2.COLOR_RGB2RGBA)
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA)
 
         if self.args.sharpen_image is not None and self.args.sharpen_image.lower() != "none":
             np.clip(new_image, 0.0, 255.0, out=new_image)


### PR DESCRIPTION
Existing -dt crashes out without success.  This PR puts the 4 channel alpha in before patching.  To my knowledge, none of the patches are 4 channel aware so we can fake a flat alpha for their purposes.