### PR TITLE
Capitalization fix

### DIFF
--- a/tools/effmpeg.py
+++ b/tools/effmpeg.py
@@ -67,7 +67,7 @@ class DataItem():
         if path is not None:
             self.path = path
         if self.path is not None:
-            item_ext = os.path.splitext(self.path)[1]
+            item_ext = os.path.splitext(self.path)[1].lower()
             if item_ext in DataItem.vid_ext:
                 item_type = 'vid'
             elif item_ext in DataItem.audio_ext:


### PR DESCRIPTION
Right now, the extension is compared against a collection of lowercase extensions to determine the type.  If the extension is capitalized at all it wont work.  To work around this, I convert the extension to lowercase to remove capitalization from the problem.