### PR TITLE
import numpy for lines 544 and 545

### DIFF
--- a/lib/model/losses.py
+++ b/lib/model/losses.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 
 import keras.backend as K
 from keras.layers import Lambda, concatenate
-import numpy
+import numpy as np
 import tensorflow as tf
 from tensorflow.contrib.distributions import Beta
 
@@ -541,8 +541,8 @@ def scharr_edges(image, magnitude):
     kernels = [[[-1.0, -2.0, -3.0, -2.0, -1.0], [-1.0, -2.0, -6.0, -2.0, -1.0], [0.0, 0.0, 0.0, 0.0, 0.0], [1.0, 2.0, 6.0, 2.0, 1.0], [1.0, 2.0, 3.0, 2.0, 1.0]],
              [[-1.0, -1.0, 0.0, 1.0, 1.0], [-2.0, -2.0, 0.0, 2.0, 2.0], [-3.0, -6.0, 0.0, 6.0, 3.0], [-2.0, -2.0, 0.0, 2.0, 2.0], [-1.0, -1.0, 0.0, 1.0, 1.0]]]
     num_kernels = len(kernels)
-    kernels = numpy.transpose(numpy.asarray(kernels), (1, 2, 0))
-    kernels = numpy.expand_dims(kernels, -2) / numpy.sum(numpy.abs(kernels))
+    kernels = np.transpose(np.asarray(kernels), (1, 2, 0))
+    kernels = np.expand_dims(kernels, -2) / np.sum(np.abs(kernels))
     kernels_tf = tf.constant(kernels, dtype=image.dtype)
     kernels_tf = tf.tile(kernels_tf, [1, 1, image_shape[-1], 1], name='scharr_filters')
 

--- a/lib/model/losses.py
+++ b/lib/model/losses.py
@@ -7,9 +7,9 @@
 
 from __future__ import absolute_import
 
-
 import keras.backend as K
 from keras.layers import Lambda, concatenate
+import numpy
 import tensorflow as tf
 from tensorflow.contrib.distributions import Beta
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/deepfakes/faceswap on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/model/losses.py:544:15: F821 undefined name 'numpy'
    kernels = numpy.transpose(numpy.asarray(kernels), (1, 2, 0))
              ^
./lib/model/losses.py:544:31: F821 undefined name 'numpy'
    kernels = numpy.transpose(numpy.asarray(kernels), (1, 2, 0))
                              ^
./lib/model/losses.py:545:15: F821 undefined name 'numpy'
    kernels = numpy.expand_dims(kernels, -2) / numpy.sum(numpy.abs(kernels))
              ^
./lib/model/losses.py:545:48: F821 undefined name 'numpy'
    kernels = numpy.expand_dims(kernels, -2) / numpy.sum(numpy.abs(kernels))
                                               ^
./lib/model/losses.py:545:58: F821 undefined name 'numpy'
    kernels = numpy.expand_dims(kernels, -2) / numpy.sum(numpy.abs(kernels))
                                                         ^
5     F821 undefined name 'numpy'
5
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree