### PR TITLE
replaced PenalizedLoss function with keras alternative

### DIFF
--- a/lib/model/losses.py
+++ b/lib/model/losses.py
@@ -167,47 +167,16 @@ class DSSIMObjective():
             patches = K.permute_dimensions(patches, [0, 1, 2, 4, 5, 3])
         return patches
 
+
 # <<< START: from Dfaker >>> #
-class PenalizedLoss():  # pylint: disable=too-few-public-methods
+def PenalizedLoss(mask, loss_func, mask_prop=1.0):
     """ Penalized Loss
         from: https://github.com/dfaker/df """
-    def __init__(self, mask, loss_func, mask_prop=1.0):
-        self.mask = mask
-        self.loss_func = loss_func
-        self.mask_prop = mask_prop
-        self.mask_as_k_inv_prop = 1-mask_prop
-
-    def __call__(self, y_true, y_pred):
-        # pylint: disable=invalid-name
-        tro, tgo, tbo = tf.split(y_true, 3, 3)
-        pro, pgo, pbo = tf.split(y_pred, 3, 3)
-
-        tr = tro
-        tg = tgo
-        tb = tbo
-
-        pr = pro
-        pg = pgo
-        pb = pbo
-        m = self.mask
-
-        m = m * self.mask_prop
-        m += self.mask_as_k_inv_prop
-        tr *= m
-        tg *= m
-        tb *= m
-
-        pr *= m
-        pg *= m
-        pb *= m
-
-        y = tf.concat([tr, tg, tb], 3)
-        p = tf.concat([pr, pg, pb], 3)
-
-        # yo = tf.stack([tro,tgo,tbo],3)
-        # po = tf.stack([pro,pgo,pbo],3)
-
-        return self.loss_func(y, p)
+    mask_as_k_inv_prop = 1 - mask_prop
+    mask = mask * mask_prop + mask_as_k_inv_prop
+    def inner_loss(y_true, y_pred):
+        return loss_func(y_true * mask, y_pred * mask)
+    return inner_loss
 # <<< END: from Dfaker >>> #
 
 

--- a/lib/model/losses.py
+++ b/lib/model/losses.py
@@ -174,6 +174,7 @@ def PenalizedLoss(mask, loss_func, mask_prop=1.0):
         from: https://github.com/dfaker/df """
     mask_as_k_inv_prop = 1 - mask_prop
     mask = mask * mask_prop + mask_as_k_inv_prop
+    mask = K.repeat_elements(mask, 3, axis=3)
     def inner_loss(y_true, y_pred):
         return loss_func(y_true * mask, y_pred * mask)
     return inner_loss


### PR DESCRIPTION
This enables plaidml backends to also use penalized mask loss.
Imo the comments around the function could be removed as, except variable naming, nothing else stayed the same.
I switched from a class to a closure because it seemed easier for that trivial piece of code.

*Ops, sorry i planed to send this PR to staging, my bad. Shouldn't matter tho i think.*