### PR TITLE
fix: remove --yes option since it has been removed in the latest dlib.

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -8,7 +8,7 @@ RUN apt-get update -qq -y \
 COPY requirements.txt /opt/
 RUN pip3 install --upgrade pip
 RUN pip3 install cmake
-RUN pip3 install dlib --install-option=--yes --install-option=USE_AVX_INSTRUCTIONS
+RUN pip3 install dlib
 RUN pip3 --no-cache-dir install -r /opt/requirements.txt && rm /opt/requirements.txt
 
 WORKDIR "/srv"

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -8,7 +8,7 @@ RUN apt-get update -qq -y \
 COPY requirements.txt /opt/
 RUN pip3 install --upgrade pip
 RUN pip3 install cmake
-RUN pip3 install dlib --install-option=--yes --install-option=USE_AVX_INSTRUCTIONS
+RUN pip3 install dlib
 RUN pip3 --no-cache-dir install -r /opt/requirements.txt && rm /opt/requirements.txt
 
 # patch for tensorflow:latest-gpu-py3 image


### PR DESCRIPTION
As described in davisking/dlib@b892df823268446012ff9717ed9544cfa891a30b: Removed --yes option from setup.py since it has long been a noop and its presence just confuses users.