### PR TITLE
fix: specific TensorFlow version to the latest 1.x(1.13.1) since it is incompatible with TensorFlow 2.x API

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:latest-py3
+FROM tensorflow/tensorflow:1.13.1-py3
 
 RUN apt-get update -qq -y \
  && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk\

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.13.1-py3
+FROM tensorflow/tensorflow:1.12.0-py3
 
 RUN apt-get update -qq -y \
  && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk\

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:latest-gpu-py3
+FROM tensorflow/tensorflow:1.13.1-gpu-py3
 
 RUN apt-get update -qq -y \
  && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk\

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.13.1-gpu-py3
+FROM tensorflow/tensorflow:1.12.0-gpu-py3
 
 RUN apt-get update -qq -y \
  && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk\


### PR DESCRIPTION
Docker tensorflow/tensorflow:latest-gpu-py3 and tensorflow/tensorflow:latest-py3 has linked to TensorFLow 2.0.0a0 which leads to faceswap run into crash.