### PR TITLE
from .layers import Scale for line 282

### DIFF
--- a/lib/model/nn_blocks.py
+++ b/lib/model/nn_blocks.py
@@ -16,7 +16,7 @@ from keras.layers.convolutional import Conv2D
 from keras.layers.core import Activation
 from keras.initializers import he_uniform, Constant, VarianceScaling
 from .initializers import ICNR
-from .layers import PixelShuffler, SubPixelUpscaling, ReflectionPadding2D
+from .layers import PixelShuffler, SubPixelUpscaling, ReflectionPadding2D, Scale
 from .normalization import GroupNormalization, InstanceNormalization
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name


### PR DESCRIPTION
As discussed in #613

[flake8](http://flake8.pycqa.org) testing of https://github.com/deepfakes/faceswap on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./lib/model/nn_blocks.py:282:13: F821 undefined name 'Scale'
    var_o = Scale()(var_o)
            ^
1     F821 undefined name 'Scale'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree