### PR TITLE
Bandaid fix for plaidml usage under Windows

### DIFF
--- a/lib/gpu_stats.py
+++ b/lib/gpu_stats.py
@@ -59,7 +59,9 @@ class GPUStats():
                     if self.logger:
                         self.logger.debug("OS is not macOS. Using pynvml")
                     pynvml.nvmlInit()
-                except (pynvml.NVMLError_LibraryNotFound, pynvml.NVMLError_DriverNotLoaded):
+                except (pynvml.NVMLError_LibraryNotFound,
+                        pynvml.NVMLError_DriverNotLoaded,
+                        pynvml.NVMLError_NoPermission):
                     self.initialized = True
                     return
             self.initialized = True


### PR DESCRIPTION
This PR catches the `pynvml.NVMLError_NoPermission` exception which was reported by an windows user with and AMD card.   
In the long term this should be replaced by an AMD/PlaidML alternative to pynvml.