### PR TITLE
build removed the --yes option and add jupyter

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -8,7 +8,7 @@ RUN apt-get update -qq -y \
 COPY requirements.txt /opt/
 RUN pip3 install --upgrade pip
 RUN pip3 install cmake
-RUN pip3 install dlib --install-option=--yes --install-option=USE_AVX_INSTRUCTIONS
+RUN pip3 install dlib==v19.16 --install-option=--yes --install-option=USE_AVX_INSTRUCTIONS
 RUN pip3 --no-cache-dir install -r /opt/requirements.txt && rm /opt/requirements.txt
 
 # patch for tensorflow:latest-gpu-py3 image

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:latest-gpu-py3-jupyter
+FROM tensorflow/tensorflow:1.12.0-gpu-py3
 
 RUN apt-get update -qq -y \
  && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk\
@@ -10,7 +10,9 @@ RUN pip3 install --upgrade pip
 RUN pip3 install cmake
 RUN pip3 install dlib
 RUN pip3 --no-cache-dir install -r /opt/requirements.txt && rm /opt/requirements.txt
-
+RUN pip3 install jupyter matplotlib
+RUN pip3 install jupyter_http_over_ws
+RUN jupyter serverextension enable --py jupyter_http_over_ws
 # patch for tensorflow:latest-gpu-py3 image
 RUN cd /usr/local/cuda/lib64 \
  && mv stubs/libcuda.so ./ \


### PR DESCRIPTION
Fix Dockerfile.gpu build failed issue
```shell
Collecting dlib
  Downloading https://files.pythonhosted.org/packages/05/57/e8a8caa3c89a27f80bc78da39c423e2553f482a3705adc619176a3a24b36/dlib-19.17.0.tar.gz (3.4MB)
Skipping bdist_wheel for dlib, due to binaries being disabled for it.
Installing collected packages: dlib
  Running setup.py install for dlib: started
    Running setup.py install for dlib: finished with status 'error'
    Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-nudyvp1a/dlib/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-biridfye/install-record.txt --single-version-externally-managed --compile --yes USE_AVX_INSTRUCTIONS:
    The --yes options to dlib's setup.py don't do anything since all these options
    are on by default.  So --yes has been removed.  Do not give it to setup.py.
    
    ----------------------------------------
/usr/local/lib/python3.5/dist-packages/pip/_internal/commands/install.py:207: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.
  cmdoptions.check_install_build_global(options)
Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-nudyvp1a/dlib/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-biridfye/install-record.txt --single-version-externally-managed --compile --yes USE_AVX_INSTRUCTIONS" failed with error code 1 in /tmp/pip-install-nudyvp1a/dlib/
```