### PR TITLE
dssim + reflective padding support for plaidml backends

### DIFF
--- a/lib/model/layers.py
+++ b/lib/model/layers.py
@@ -18,6 +18,10 @@ from keras.utils.generic_utils import get_custom_objects
 from keras import initializers
 from keras.layers import ZeroPadding2D
 
+if K.backend() == "plaidml.keras.backend":
+    from lib.plaidml_utils import pad
+else:
+    from tensorflow import pad 
 
 class PixelShuffler(Layer):
     """ PixelShuffler layer for Keras
@@ -319,7 +323,7 @@ class ReflectionPadding2D(Layer):
         padding_left = padding_width // 2
         padding_right = padding_width - padding_left
 
-        return tf.pad(x, [[0,0],
+        return pad(x, [[0,0],
                           [padding_top, padding_bot],
                           [padding_left, padding_right],
                           [0,0] ],

--- a/lib/model/losses.py
+++ b/lib/model/losses.py
@@ -14,6 +14,10 @@ import tensorflow as tf
 from tensorflow.contrib.distributions import Beta
 
 from .normalization import InstanceNormalization
+if K.backend() == "plaidml.keras.backend":
+    from lib.plaidml_utils import extract_image_patches
+else:
+    from tensorflow import extract_image_patches
 
 
 class DSSIMObjective():
@@ -92,11 +96,7 @@ class DSSIMObjective():
                                                   kernel,
                                                   'valid',
                                                   self.dim_ordering)
-
-        # Reshape to get the var in the cells
-        _, w, h, c1, c2, c3 = self.__int_shape(patches_pred)
-        patches_pred = K.reshape(patches_pred, [-1, w, h, c1 * c2 * c3])
-        patches_true = K.reshape(patches_true, [-1, w, h, c1 * c2 * c3])
+        
         # Get mean
         u_true = K.mean(patches_true, axis=-1)
         u_pred = K.mean(patches_pred, axis=-1)
@@ -152,19 +152,8 @@ class DSSIMObjective():
         padding = self._preprocess_padding(padding)
         if data_format == 'channels_first':
             x = K.permute_dimensions(x, (0, 2, 3, 1))
-        _, _, _, ch_i = K.int_shape(x)
-        patches = tf.extract_image_patches(x, kernel, strides, [1, 1, 1, 1],
+        patches = extract_image_patches(x, kernel, strides, [1, 1, 1, 1],
                                            padding)
-        # Reshaping to fit Theano
-        _, w, h, ch = K.int_shape(patches)
-        patches = tf.reshape(tf.transpose(tf.reshape(patches,
-                                                     [-1, w, h,
-                                                      tf.floordiv(ch, ch_i),
-                                                      ch_i]),
-                                          [0, 1, 2, 4, 3]),
-                             [-1, w, h, ch_i, ksizes[0], ksizes[1]])
-        if data_format == 'channels_last':
-            patches = K.permute_dimensions(patches, [0, 1, 2, 4, 5, 3])
         return patches
 
 

--- a/lib/plaidml_utils.py
+++ b/lib/plaidml_utils.py
@@ -1,0 +1,99 @@
+'''
+Multiple plaidml implementation.
+'''
+
+import plaidml
+from plaidml.keras import backend as K
+import math
+
+class ImagePatches(plaidml.tile.Operation):
+    def __init__(self, images, ksizes, strides, rates=(1,1,1,1), padding="VALID", name=None):
+        """
+        Compatible to tensorflow.extract_image_patches.
+        Extract patches from images and put them in the "depth" output dimension.
+        Args:
+            images: A tensor with a shape of [batch, rows, cols, depth]
+            ksizes: The size of the oatches with a shape of [1, patch_rows, patch_cols, 1]
+            strides: How far the center of two patches are in the image with a shape of [1, stride_rows, stride_cols, 1]
+            rates: How far two consecutive pixel are in the input. Equivalent to dilation. Expect shape of [1, rate_rows, rate_cols, 1]
+            padding: A string of "VALID" or "SAME" defining padding.
+        """
+        i_shape = images.shape.dims
+        patch_row_eff = ksizes[1] + ((ksizes[1] - 1) * (rates[1] -1))
+        patch_col_eff = ksizes[2] + ((ksizes[2] - 1) * (rates[2] -1))
+
+        if padding.upper() == "VALID":
+            out_rows = math.ceil((i_shape[1] - patch_row_eff + 1.) / float(strides[1]))
+            out_cols = math.ceil((i_shape[2] - patch_col_eff + 1.) / float(strides[2]))
+            pad_top = 0
+            pad_left = 0
+        else:
+            out_rows = math.ceil( i_shape[1] / float(strides[1]) )
+            out_cols = math.ceil( i_shape[2] / float(strides[2]) )
+            pad_top = max(0, ( (out_rows - 1) * strides[1] + patch_row_eff - i_shape[1] ) // 2)
+            pad_left = max(0, ( (out_cols - 1) * strides[2] + patch_col_eff - i_shape[2] ) // 2)
+            # we simply assume padding right == padding left + 1 (same for top/down).
+            # This might lead to us padding more as we would need but that won't matter.
+            # TF tries to split padding between both sides so pad_left +1 should keep us on the safe side.
+            images = K.spatial_2d_padding(images, ((pad_top, pad_top+1), (pad_left, pad_left+1)))
+
+        o_shape = (i_shape[0], out_rows, out_cols, ksizes[1]*ksizes[2]*i_shape[-1])
+        code = """function (I[B,Y,X,D]) -> (O) {{
+                    TMP[b, ny, nx, y, x, d: B, {NY}, {NX}, {KY}, {KX}, D] =
+                        =(I[b, ny * {SY} + y * {RY}, nx * {SX} + x * {RX}, d]);
+                    O = reshape(TMP, B, {NY}, {NX}, {KY} * {KX} * D);
+                }}
+        """.format(
+            NY=out_rows, NX=out_cols,
+            KY=ksizes[1], KX=ksizes[2],
+            SY=strides[1], SX=strides[2],
+            RY=rates[1], RX=rates[2]
+        )
+        super(ImagePatches, self).__init__(
+            code,
+            [('I', images),],
+            [('O', plaidml.tile.Shape(images.shape.dtype, o_shape))],
+            name=name
+        )
+
+
+extract_image_patches = ImagePatches.function
+
+
+def reflection_padding(inp, paddings):
+    paddings = [(x, x) if isinstance(x, int) else x for x in paddings]
+    ishape = inp.shape.dims
+    ndims = inp.shape.ndims
+    if len(ishape) != len(paddings):
+        raise ValueError("Padding dims != input dims")
+    last = inp
+    _all_slice = slice(None, None, None)
+    
+    def _get_slices(ndims, axis, slice_):
+        ret = [_all_slice for _ in range(ndims)]
+        ret[axis] = slice_
+        return tuple(ret)
+    
+    for axis, pads in ((i, x) for i, x in enumerate(paddings) if x[0]+x[1] != 0):
+        pad_data = []
+        if pads[0]:
+            pre = last[_get_slices(ndims, axis, slice(pads[0], 0, -1))]
+            pad_data.append(pre)
+        pad_data.append(last)
+        if pads[1]:
+            post = last[_get_slices(ndims, axis, slice(-2, -pads[1]-2, -1))]
+            pad_data.append(post)
+        last = K.concatenate(pad_data, axis)
+        ishape = last.shape.dims
+    return last
+
+
+def pad(data, paddings, mode="CONSTANT", name=None, constant_value=0):
+    # TODO: use / impl other padding method
+    # CONSTANT -> SpatialPadding ? | Doesn't support first and last axis + no support for constant_value
+    # SYMMETRIC -> Requires impl ?
+    if mode.upper() != "REFLECT":
+        raise NotImplementedError("pad only supports mode == 'REFLECT'")
+    if constant_value != 0:
+        raise NotImplementedError("pad does not support constant_value != 0")
+    return reflection_padding(data, paddings)


### PR DESCRIPTION
This PR adds support for dssim loss and reflective padding for plaidml backends.
It also removes some unnecessary reshaping which was there to support theano backends.

This code should be tested with a tensorflow backend to make sure the changes to remove the reshaping didn't break anything, although i am pretty sure it didn't.