### PR TITLE
Convert settings tool

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -111,7 +111,7 @@ class FaceswapConfig():
         self.defaults[title]["helptext"] = info
 
     def add_item(self, section=None, title=None, datatype=str, default=None, info=None,
-                 rounding=None, min_max=None, choices=None, fixed=True):
+                 rounding=None, min_max=None, choices=None, gui_radio=False, fixed=True):
         """ Add a default item to a config section
 
             For int or float values, rounding and min_max must be set
@@ -122,6 +122,9 @@ class FaceswapConfig():
             For str values choices can be set to validate input and create a combo box
             in the GUI
 
+            is_radio is to indicate to the GUI that it should display Radio Buttons rather than
+            combo boxes for multiple choice options.
+
             The 'fixed' parameter is only for training configs. Training configurations
             are set when the model is created, and then reloaded from the state file.
             Marking an item as fixed=False indicates that this value can be changed for
@@ -130,8 +133,9 @@ class FaceswapConfig():
 
         """
         logger.debug("Add item: (section: '%s', title: '%s', datatype: '%s', default: '%s', "
-                     "info: '%s', rounding: '%s', min_max: %s, choices: %s, fixed: %s)",
-                     section, title, datatype, default, info, rounding, min_max, choices, fixed)
+                     "info: '%s', rounding: '%s', min_max: %s, choices: %s, gui_radio: %s, "
+                     "fixed: %s)", section, title, datatype, default, info, rounding, min_max,
+                     choices, gui_radio, fixed)
 
         choices = list() if not choices else choices
 
@@ -156,6 +160,7 @@ class FaceswapConfig():
                                          "rounding": rounding,
                                          "min_max": min_max,
                                          "choices": choices,
+                                         "gui_radio": gui_radio,
                                          "fixed": fixed}
 
     @staticmethod

--- a/lib/convert.py
+++ b/lib/convert.py
@@ -33,32 +33,36 @@ class Converter():
         self.load_plugins()
         logger.debug("Initialized %s", self.__class__.__name__)
 
-    def reinitialize(self):
+    def reinitialize(self, config):
         """ reinitialize converter """
         logger.debug("Reinitializing converter")
         self.adjustments = dict(box=None, mask=None, color=None, seamless=None, scaling=None)
-        self.load_plugins()
+        self.load_plugins(config=config)
         logger.debug("Reinitialized converter")
 
-    def load_plugins(self):
+    def load_plugins(self, config=None):
         """ Load the requested adjustment plugins """
-        logger.debug("Loading plugins")
+        logger.debug("Loading plugins. config: %s", config)
         self.adjustments["box"] = PluginLoader.get_converter("mask", "box_blend")(
             "none",
-            self.output_size)
+            self.output_size,
+            config=config)
 
         self.adjustments["mask"] = PluginLoader.get_converter("mask", "mask_blend")(
             self.args.mask_type,
             self.output_size,
-            self.output_has_mask)
+            self.output_has_mask,
+            config=config)
 
         if self.args.color_adjustment != "none" and self.args.color_adjustment is not None:
-            self.adjustments["color"] = PluginLoader.get_converter("color",
-                                                                   self.args.color_adjustment)()
+            self.adjustments["color"] = PluginLoader.get_converter(
+                "color",
+                self.args.color_adjustment)(config=config)
 
         if self.args.scaling != "none" and self.args.scaling is not None:
-            self.adjustments["scaling"] = PluginLoader.get_converter("scaling",
-                                                                     self.args.scaling)()
+            self.adjustments["scaling"] = PluginLoader.get_converter(
+                "scaling",
+                self.args.scaling)(config=config)
         logger.debug("Loaded plugins: %s", self.adjustments)
 
     def process(self, in_queue, out_queue):

--- a/lib/convert.py
+++ b/lib/convert.py
@@ -26,22 +26,31 @@ class Converter():
         self.draw_transparent = draw_transparent
         self.writer_pre_encode = pre_encode
         self.scale = arguments.output_scale / 100
+        self.output_size = output_size
+        self.output_has_mask = output_has_mask
         self.args = arguments
         self.adjustments = dict(box=None, mask=None, color=None, seamless=None, scaling=None)
-        self.load_plugins(output_size, output_has_mask)
+        self.load_plugins()
         logger.debug("Initialized %s", self.__class__.__name__)
 
-    def load_plugins(self, output_size, output_has_mask):
+    def reinitialize(self):
+        """ reinitialize converter """
+        logger.debug("Reinitializing converter")
+        self.adjustments = dict(box=None, mask=None, color=None, seamless=None, scaling=None)
+        self.load_plugins()
+        logger.debug("Reinitialized converter")
+
+    def load_plugins(self):
         """ Load the requested adjustment plugins """
         logger.debug("Loading plugins")
         self.adjustments["box"] = PluginLoader.get_converter("mask", "box_blend")(
             "none",
-            output_size)
+            self.output_size)
 
         self.adjustments["mask"] = PluginLoader.get_converter("mask", "mask_blend")(
             self.args.mask_type,
-            output_size,
-            output_has_mask)
+            self.output_size,
+            self.output_has_mask)
 
         if self.args.color_adjustment != "none" and self.args.color_adjustment is not None:
             self.adjustments["color"] = PluginLoader.get_converter("color",

--- a/lib/convert.py
+++ b/lib/convert.py
@@ -37,32 +37,38 @@ class Converter():
         """ reinitialize converter """
         logger.debug("Reinitializing converter")
         self.adjustments = dict(box=None, mask=None, color=None, seamless=None, scaling=None)
-        self.load_plugins(config=config)
+        self.load_plugins(config=config, disable_logging=True)
         logger.debug("Reinitialized converter")
 
-    def load_plugins(self, config=None):
+    def load_plugins(self, config=None, disable_logging=False):
         """ Load the requested adjustment plugins """
         logger.debug("Loading plugins. config: %s", config)
-        self.adjustments["box"] = PluginLoader.get_converter("mask", "box_blend")(
-            "none",
-            self.output_size,
-            config=config)
+        self.adjustments["box"] = PluginLoader.get_converter(
+            "mask",
+            "box_blend",
+            disable_logging=disable_logging)("none",
+                                             self.output_size,
+                                             config=config)
 
-        self.adjustments["mask"] = PluginLoader.get_converter("mask", "mask_blend")(
-            self.args.mask_type,
-            self.output_size,
-            self.output_has_mask,
-            config=config)
+        self.adjustments["mask"] = PluginLoader.get_converter(
+            "mask",
+            "mask_blend",
+            disable_logging=disable_logging)(self.args.mask_type,
+                                             self.output_size,
+                                             self.output_has_mask,
+                                             config=config)
 
         if self.args.color_adjustment != "none" and self.args.color_adjustment is not None:
             self.adjustments["color"] = PluginLoader.get_converter(
                 "color",
-                self.args.color_adjustment)(config=config)
+                self.args.color_adjustment,
+                disable_logging=disable_logging)(config=config)
 
         if self.args.scaling != "none" and self.args.scaling is not None:
             self.adjustments["scaling"] = PluginLoader.get_converter(
                 "scaling",
-                self.args.scaling)(config=config)
+                self.args.scaling,
+                disable_logging=disable_logging)(config=config)
         logger.debug("Loaded plugins: %s", self.adjustments)
 
     def process(self, in_queue, out_queue):

--- a/lib/gui/command.py
+++ b/lib/gui/command.py
@@ -8,10 +8,10 @@ from tkinter import ttk
 from .tooltip import Tooltip
 from .utils import ContextMenu, FileHandler, get_images, get_config, set_slider_rounding
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)  #pylint:disable=invalid-name
 
 
-class CommandNotebook(ttk.Notebook):  # pylint: disable=too-many-ancestors
+class CommandNotebook(ttk.Notebook):  #pylint:disable=too-many-ancestors
     """ Frame to hold each individual tab of the command notebook """
 
     def __init__(self, parent):
@@ -19,10 +19,11 @@ class CommandNotebook(ttk.Notebook):  # pylint: disable=too-many-ancestors
         scaling_factor = get_config().scaling_factor
         width = int(420 * scaling_factor)
         height = int(500 * scaling_factor)
-        ttk.Notebook.__init__(self, parent, width=width, height=height)
+        self.actionbtns = dict()
+        super().__init__(parent, width=width, height=height)
         parent.add(self)
 
-        self.actionbtns = dict()
+        self.tools_notebook = ToolsNotebook(self)
         self.set_running_task_trace()
         self.build_tabs()
         get_config().command_notebook = self
@@ -40,11 +41,13 @@ class CommandNotebook(ttk.Notebook):  # pylint: disable=too-many-ancestors
         logger.debug("Build Tabs")
         cli_opts = get_config().cli_opts
         for category in cli_opts.categories:
+            book = self.tools_notebook if category == "tools" else self
             cmdlist = cli_opts.commands[category]
             for command in cmdlist:
                 title = command.title()
-                commandtab = CommandTab(self, category, command)
-                self.add(commandtab, text=title)
+                commandtab = CommandTab(book, category, command)
+                book.add(commandtab, text=title)
+        self.add(self.tools_notebook, text="Tools")
         logger.debug("Built Tabs")
 
     def change_action_button(self, *args):
@@ -65,13 +68,20 @@ class CommandNotebook(ttk.Notebook):  # pylint: disable=too-many-ancestors
             Tooltip(btnact, text=hlp, wraplength=200)
 
 
-class CommandTab(ttk.Frame):  # pylint: disable=too-many-ancestors
+class ToolsNotebook(ttk.Notebook):  #pylint:disable=too-many-ancestors
+    """ Tools sit in their own tab, but need to inherit objects from the main command notebook """
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.actionbtns = parent.actionbtns
+
+
+class CommandTab(ttk.Frame):  #pylint:disable=too-many-ancestors
     """ Frame to hold each individual tab of the command notebook """
 
     def __init__(self, parent, category, command):
         logger.debug("Initializing %s: (category: '%s', command: '%s')",
                      self.__class__.__name__, category, command)
-        ttk.Frame.__init__(self, parent)
+        super().__init__(parent)
 
         self.category = category
         self.actionbtns = parent.actionbtns
@@ -98,12 +108,12 @@ class CommandTab(ttk.Frame):  # pylint: disable=too-many-ancestors
         logger.debug("Added frame seperator")
 
 
-class OptionsFrame(ttk.Frame):  # pylint: disable=too-many-ancestors
+class OptionsFrame(ttk.Frame):  #pylint:disable=too-many-ancestors
     """ Options Frame - Holds the Options for each command """
 
     def __init__(self, parent):
         logger.debug("Initializing %s", self.__class__.__name__)
-        ttk.Frame.__init__(self, parent)
+        super().__init__(parent)
         self.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
 
         self.command = parent.command
@@ -168,7 +178,7 @@ class OptionsFrame(ttk.Frame):  # pylint: disable=too-many-ancestors
         self.optsframe.bind("<Configure>", self.update_scrollbar)
         logger.debug("Added Options Scrollbar")
 
-    def update_scrollbar(self, event):  # pylint: disable=unused-argument
+    def update_scrollbar(self, event):  #pylint:disable=unused-argument
         """ Update the options frame scrollbar """
         self.canvas.configure(scrollregion=self.canvas.bbox("all"))
 
@@ -405,7 +415,7 @@ class OptionControl():
             filepath.set(filename)
 
     @staticmethod
-    def ask_nothing(filepath, filetypes=None):  # pylint: disable=unused-argument
+    def ask_nothing(filepath, filetypes=None):  #pylint:disable=unused-argument
         """ Method that does nothing, used for disabling open/save pop up """
         return
 
@@ -424,12 +434,12 @@ class OptionControl():
             filepath.set(filename)
 
 
-class ActionFrame(ttk.Frame):  # pylint: disable=too-many-ancestors
+class ActionFrame(ttk.Frame):  #pylint:disable=too-many-ancestors
     """Action Frame - Displays action controls for the command tab """
 
     def __init__(self, parent):
         logger.debug("Initializing %s: (command: '%s')", self.__class__.__name__, parent.command)
-        ttk.Frame.__init__(self, parent)
+        super().__init__(parent)
         self.pack(fill=tk.BOTH, padx=5, pady=5, side=tk.BOTTOM, anchor=tk.N)
 
         self.command = parent.command

--- a/lib/gui/command.py
+++ b/lib/gui/command.py
@@ -8,10 +8,10 @@ from tkinter import ttk
 from .tooltip import Tooltip
 from .utils import ContextMenu, FileHandler, get_images, get_config, set_slider_rounding
 
-logger = logging.getLogger(__name__)  #pylint:disable=invalid-name
+logger = logging.getLogger(__name__)  # pylint:disable=invalid-name
 
 
-class CommandNotebook(ttk.Notebook):  #pylint:disable=too-many-ancestors
+class CommandNotebook(ttk.Notebook):  # pylint:disable=too-many-ancestors
     """ Frame to hold each individual tab of the command notebook """
 
     def __init__(self, parent):
@@ -68,14 +68,14 @@ class CommandNotebook(ttk.Notebook):  #pylint:disable=too-many-ancestors
             Tooltip(btnact, text=hlp, wraplength=200)
 
 
-class ToolsNotebook(ttk.Notebook):  #pylint:disable=too-many-ancestors
+class ToolsNotebook(ttk.Notebook):  # pylint:disable=too-many-ancestors
     """ Tools sit in their own tab, but need to inherit objects from the main command notebook """
     def __init__(self, parent):
         super().__init__(parent)
         self.actionbtns = parent.actionbtns
 
 
-class CommandTab(ttk.Frame):  #pylint:disable=too-many-ancestors
+class CommandTab(ttk.Frame):  # pylint:disable=too-many-ancestors
     """ Frame to hold each individual tab of the command notebook """
 
     def __init__(self, parent, category, command):
@@ -108,7 +108,7 @@ class CommandTab(ttk.Frame):  #pylint:disable=too-many-ancestors
         logger.debug("Added frame seperator")
 
 
-class OptionsFrame(ttk.Frame):  #pylint:disable=too-many-ancestors
+class OptionsFrame(ttk.Frame):  # pylint:disable=too-many-ancestors
     """ Options Frame - Holds the Options for each command """
 
     def __init__(self, parent):
@@ -178,7 +178,7 @@ class OptionsFrame(ttk.Frame):  #pylint:disable=too-many-ancestors
         self.optsframe.bind("<Configure>", self.update_scrollbar)
         logger.debug("Added Options Scrollbar")
 
-    def update_scrollbar(self, event):  #pylint:disable=unused-argument
+    def update_scrollbar(self, event):  # pylint:disable=unused-argument
         """ Update the options frame scrollbar """
         self.canvas.configure(scrollregion=self.canvas.bbox("all"))
 
@@ -415,7 +415,7 @@ class OptionControl():
             filepath.set(filename)
 
     @staticmethod
-    def ask_nothing(filepath, filetypes=None):  #pylint:disable=unused-argument
+    def ask_nothing(filepath, filetypes=None):  # pylint:disable=unused-argument
         """ Method that does nothing, used for disabling open/save pop up """
         return
 
@@ -434,7 +434,7 @@ class OptionControl():
             filepath.set(filename)
 
 
-class ActionFrame(ttk.Frame):  #pylint:disable=too-many-ancestors
+class ActionFrame(ttk.Frame):  # pylint:disable=too-many-ancestors
     """Action Frame - Displays action controls for the command tab """
 
     def __init__(self, parent):

--- a/lib/gui/utils.py
+++ b/lib/gui/utils.py
@@ -32,13 +32,13 @@ def get_config():
     return _CONFIG
 
 
-def initialize_images():
-    """ Initialize the config and add to global constant """
+def initialize_images(pathcache=None):
+    """ Initialize the images and add to global constant """
     global _IMAGES  # pylint: disable=global-statement
     if _IMAGES is not None:
         return
     logger.debug("Initializing images")
-    _IMAGES = Images()
+    _IMAGES = Images(pathcache)
 
 
 def get_images():
@@ -219,9 +219,9 @@ class Images():
         Don't call directly. Call get_images()
     """
 
-    def __init__(self):
+    def __init__(self, pathcache=None):
         logger.debug("Initializing %s", self.__class__.__name__)
-        pathcache = get_config().pathcache
+        pathcache = get_config().pathcache if pathcache is None else pathcache
         self.pathicons = os.path.join(pathcache, "icons")
         self.pathpreview = os.path.join(pathcache, "preview")
         self.pathoutput = None

--- a/lib/gui/utils.py
+++ b/lib/gui/utils.py
@@ -683,7 +683,7 @@ class ControlBuilder():
 
         self.frame = self.control_frame(parent, helptext)
         self.control = self.set_control(dtype, choices, is_radio)
-        self.tk_var = self.set_tk_var(selected_value)
+        self.tk_var = self.set_tk_var(dtype, selected_value)
 
         self.build_control(choices, dtype, rounding, min_max, radio_columns)
         logger.debug("Initialized: %s", self.__class__.__name__)
@@ -723,10 +723,18 @@ class ControlBuilder():
         logger.debug("Setting control '%s' to %s", self.title, control)
         return control
 
-    def set_tk_var(self, selected_value):
+    def set_tk_var(self, dtype, selected_value):
         """ Correct variable type for control """
-        logger.debug("Setting tk variable: '%s'", self.title)
-        var = tk.BooleanVar if self.control == ttk.Checkbutton else tk.StringVar
+        logger.debug("Setting tk variable: (title: '%s', dtype: %s, selected_value: %s)",
+                     self.title, dtype, selected_value)
+        if dtype == bool:
+            var = tk.BooleanVar
+        elif dtype == int:
+            var = tk.IntVar
+        elif dtype == float:
+            var = tk.DoubleVar
+        else:
+            var = tk.StringVar
         var = var(self.frame)
         val = self.default if selected_value is None else selected_value
         var.set(val)

--- a/lib/gui/utils.py
+++ b/lib/gui/utils.py
@@ -10,6 +10,7 @@ from tkinter import filedialog, ttk
 from PIL import Image, ImageTk
 
 from lib.Serializer import JSONSerializer
+from .tooltip import Tooltip
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 _CONFIG = None
@@ -389,7 +390,8 @@ class ContextMenu(tk.Menu):  # pylint: disable=too-many-ancestors
         """ Bind the menu to the widget's Right Click event """
         button = "<Button-2>" if platform.system() == "Darwin" else "<Button-3>"
         logger.debug("Binding '%s' to '%s'", button, self.widget.winfo_class())
-        x_offset = int(34 * get_config().scaling_factor)
+        scaling_factor = get_config().scaling_factor if get_config() is not None else 1.0
+        x_offset = int(34 * scaling_factor)
         self.widget.bind(button,
                          lambda event: self.tk_popup(event.x_root + x_offset, event.y_root, 0))
 
@@ -633,3 +635,186 @@ class Config():
         recent_json = self.serializer.marshal(recent_files)
         with open(recent_filename, "wb") as out:
             out.write(recent_json.encode("utf-8"))
+
+
+class ControlBuilder():
+    # TODO Expand out for cli options
+    """
+    Builds and returns a frame containing a tkinter control with label
+
+    Currently only setup for config items
+
+    Parameters
+    ----------
+    parent: tkinter object
+        Parent tkinter object
+    title: str
+        Title of the control. Will be used for label text
+    dtype: datatype object
+        Datatype of the control
+    default: str
+        Default value for the control
+    selected_value: str, optional
+        Selected value for the control. If None, default will be used
+    choices: list or tuple, object
+        Used for combo boxes and radio control option setting
+    is_radio: bool, optional
+        Specifies to use a Radio control instead of combobox if choices are passed
+    rounding: int or float, optional
+        For slider controls. Sets the stepping
+    min_max: int or float, optional
+        For slider controls. Sets the min and max values
+    helptext: str, optional
+        Sets the tooltip text
+    radio_columns: int, optional
+        Sets the number of columns to use for grouping radio buttons
+    """
+    def __init__(self, parent, title, dtype, default,
+                 selected_value=None, choices=None, is_radio=False, rounding=None,
+                 min_max=None, helptext=None, radio_columns=3):
+        logger.debug("Initializing %s: (parent: %s, title: %s, dtype: %s, default: %s, "
+                     "selected_value: %s, choices: %s, is_radio: %s, rounding: %s, min_max: %s, "
+                     "helptext: %s, radio_columns: %s)", self.__class__.__name__, parent, title,
+                     dtype, default, selected_value, choices, is_radio, rounding, min_max,
+                     helptext, radio_columns)
+
+        self.title = title
+        self.default = default
+
+        self.frame = self.control_frame(parent, helptext)
+        self.control = self.set_control(dtype, choices, is_radio)
+        self.tk_var = self.set_tk_var(selected_value)
+
+        self.build_control(choices, dtype, rounding, min_max, radio_columns)
+        logger.debug("Initialized: %s", self.__class__.__name__)
+
+    # Frame, control type and varable
+    def control_frame(self, parent, helptext):
+        """ Frame to hold control and it's label """
+        logger.debug("Build control frame")
+        frame = ttk.Frame(parent)
+        frame.pack(fill=tk.X, expand=True)
+        if helptext is not None:
+            helptext = self.format_helptext(helptext)
+            Tooltip(frame, text=helptext, wraplength=720)
+        logger.debug("Built control frame")
+        return frame
+
+    def format_helptext(self, helptext):
+        """ Format the help text for tooltips """
+        logger.debug("Format control help: '%s'", self.title)
+        helptext = helptext.replace("\n\t", "\n  - ").replace("%%", "%")
+        helptext = self.title + " - " + helptext
+        logger.debug("Formatted control help: (title: '%s', help: '%s'", self.title, helptext)
+        return helptext
+
+    def set_control(self, dtype, choices, is_radio):
+        """ Set the correct control type based on the datatype or for this option """
+        if choices and is_radio:
+            control = ttk.Radiobutton
+        elif choices:
+            control = ttk.Combobox
+        elif dtype == bool:
+            control = ttk.Checkbutton
+        elif dtype in (int, float):
+            control = ttk.Scale
+        else:
+            control = ttk.Entry
+        logger.debug("Setting control '%s' to %s", self.title, control)
+        return control
+
+    def set_tk_var(self, selected_value):
+        """ Correct variable type for control """
+        logger.debug("Setting tk variable: '%s'", self.title)
+        var = tk.BooleanVar if self.control == ttk.Checkbutton else tk.StringVar
+        var = var(self.frame)
+        val = self.default if selected_value is None else selected_value
+        var.set(val)
+        logger.debug("Set tk variable: (title: '%s', type: %s, value: '%s')",
+                     self.title, type(var), val)
+        return var
+
+    # Build the full control
+    def build_control(self, choices, dtype, rounding, min_max, radio_columns):
+        """ Build the correct control type for the option passed through """
+        logger.debug("Build confog option control")
+        self.build_control_label()
+        self.build_one_control(choices, dtype, rounding, min_max, radio_columns)
+        logger.debug("Built option control")
+
+    def build_control_label(self):
+        """ Label for control """
+        logger.debug("Build control label: '%s'", self.title)
+        title = self.title.replace("_", " ").title()
+        lbl = ttk.Label(self.frame, text=title, width=20, anchor=tk.W)
+        lbl.pack(padx=5, pady=5, side=tk.LEFT, anchor=tk.N)
+        logger.debug("Built control label: '%s'", self.title)
+
+    def build_one_control(self, choices, dtype, rounding, min_max, radio_columns):
+        """ Build and place the option controls """
+        logger.debug("Build control: (title: '%s', control: %s, choices: %s, dtype: %s, "
+                     "rounding: %s, min_max: %s)", self.title, self.control, choices, dtype,
+                     rounding, min_max)
+        if self.control == ttk.Scale:
+            ctl = self.slider_control(dtype, rounding, min_max)
+        elif self.control == ttk.Radiobutton:
+            ctl = self.radio_control(choices, radio_columns)
+        else:
+            ctl = self.control_to_optionsframe(choices)
+        ctl.pack(padx=5, pady=5, fill=tk.X, expand=True)
+        logger.debug("Built control: '%s'", self.title)
+
+    def radio_control(self, choices, columns):
+        """ Create a group of radio buttons """
+        logger.debug("Adding radio group: %s", self.title)
+        ctl = ttk.Frame(self.frame)
+        frames = list()
+        for _ in range(columns):
+            frame = ttk.Frame(ctl)
+            frame.pack(padx=5, pady=5, fill=tk.X, expand=True, side=tk.LEFT, anchor=tk.N)
+            frames.append(frame)
+
+        for idx, choice in enumerate(choices):
+            frame_id = idx % columns
+            radio = ttk.Radiobutton(frames[frame_id],
+                                    text=choice.title(),
+                                    value=choice,
+                                    variable=self.tk_var)
+            radio.pack(anchor=tk.W)
+            logger.debug("Adding radio option %s to column %s", choice, frame_id)
+        logger.debug("Added radio group: '%s'", self.title)
+        return ctl
+
+    def slider_control(self, dtype, rounding, min_max):
+        """ A slider control with corresponding Entry box """
+        logger.debug("Add slider control to Options Frame: (title: '%s', dtype: %s, rounding: %s, "
+                     "min_max: %s)", self.title, dtype, rounding, min_max)
+        tbox = ttk.Entry(self.frame, width=8, textvariable=self.tk_var, justify=tk.RIGHT)
+        tbox.pack(padx=(0, 5), side=tk.RIGHT)
+        ctl = self.control(
+            self.frame,
+            variable=self.tk_var,
+            command=lambda val, var=self.tk_var, dt=dtype, rn=rounding, mm=min_max:
+            set_slider_rounding(val, var, dt, rn, mm))
+        rc_menu = ContextMenu(tbox)
+        rc_menu.cm_bind()
+        ctl["from_"] = min_max[0]
+        ctl["to"] = min_max[1]
+        logger.debug("Added slider control to Options Frame: %s", self.title)
+        return ctl
+
+    def control_to_optionsframe(self, choices):
+        """ Standard non-check buttons sit in the main options frame """
+        logger.debug("Add control to Options Frame: (title: '%s', control: %s, choices: %s)",
+                     self.title, self.control, choices)
+        if self.control == ttk.Checkbutton:
+            ctl = self.control(self.frame, variable=self.tk_var, text=None)
+        else:
+            ctl = self.control(self.frame, textvariable=self.tk_var)
+            rc_menu = ContextMenu(ctl)
+            rc_menu.cm_bind()
+        if choices:
+            logger.debug("Adding combo choices: %s", choices)
+            ctl["values"] = [choice for choice in choices]
+        logger.debug("Added control to Options Frame: %s", self.title)
+        return ctl

--- a/lib/queue_manager.py
+++ b/lib/queue_manager.py
@@ -86,11 +86,16 @@ class QueueManager():
 
     def flush_queues(self):
         """ Empty out all queues """
-        for q_name, queue in self.queues.items():
-            logger.debug("QueueManager flushing: '%s'", q_name)
-            while not queue.empty():
-                queue.get(True, 1)
+        for q_name in self.queues.keys():
+            self.flush_queue(q_name)
         logger.debug("QueueManager flushed all queues")
+
+    def flush_queue(self, q_name):
+        """ Empty out a specific queue """
+        logger.debug("QueueManager flushing: '%s'", q_name)
+        queue = self.queues[q_name]
+        while not queue.empty():
+            queue.get(True, 1)
 
     def debug_monitor(self, update_secs=2):
         """ Debug tool for monitoring queues """

--- a/lib/queue_manager.py
+++ b/lib/queue_manager.py
@@ -78,12 +78,19 @@ class QueueManager():
             To be called if there is an error """
         logger.debug("QueueManager terminating all queues")
         self.shutdown.set()
+        self.flush_queues()
         for q_name, queue in self.queues.items():
             logger.debug("QueueManager terminating: '%s'", q_name)
-            while not queue.empty():
-                queue.get(True, 1)
             queue.put("EOF")
         logger.debug("QueueManager terminated all queues")
+
+    def flush_queues(self):
+        """ Empty out all queues """
+        for q_name, queue in self.queues.items():
+            logger.debug("QueueManager flushing: '%s'", q_name)
+            while not queue.empty():
+                queue.get(True, 1)
+        logger.debug("QueueManager flushed all queues")
 
     def debug_monitor(self, update_secs=2):
         """ Debug tool for monitoring queues """

--- a/plugins/convert/_config.py
+++ b/plugins/convert/_config.py
@@ -34,7 +34,7 @@ class Config(FaceswapConfig):
                               "background image")
         self.add_item(
             section=section, title="type", datatype=str, choices=BLUR_TYPES, default="gaussian",
-            info=BLUR_INFO)
+            info=BLUR_INFO, gui_radio=True)
         self.add_item(
             section=section, title="distance", datatype=float, default=11.0, rounding=1,
             min_max=(0.1, 25.0),
@@ -69,7 +69,7 @@ class Config(FaceswapConfig):
                               "background image")
         self.add_item(
             section=section, title="type", datatype=str, choices=BLUR_TYPES, default="normalized",
-            info=BLUR_INFO)
+            info=BLUR_INFO, gui_radio=True)
         self.add_item(
             section=section, title="radius", datatype=float, default=3.0, rounding=1,
             min_max=(0.1, 25.0),
@@ -135,6 +135,7 @@ class Config(FaceswapConfig):
         self.add_item(
             section=section, title="method", datatype=str,
             choices=["box", "gaussian", "unsharp_mask"], default="unsharp_mask",
+            gui_radio=True,
             info="The type of sharpening to use: "
                  "\n\t box: Fastest, but weakest method. Uses a box filter to assess edges."
                  "\n\t gaussian: Slower, but better than box. Uses a gaussian filter to assess "
@@ -202,6 +203,7 @@ class Config(FaceswapConfig):
         self.add_item(
             section=section, title="format", datatype=str, default="png",
             choices=["bmp", "jpg", "jp2", "png", "ppm"],
+            gui_radio=True,
             info="Image format to use:"
                  "\n\t bmp: Windows bitmap"
                  "\n\t jpg: JPEG format"
@@ -232,6 +234,7 @@ class Config(FaceswapConfig):
         self.add_item(
             section=section, title="format", datatype=str, default="png",
             choices=["bmp", "gif", "jpg", "jp2", "png", "ppm", "tif"],
+            gui_radio=True,
             info="Image format to use:"
                  "\n\t bmp: Windows bitmap"
                  "\n\t gif: Graphics Interchange Format (NB: Not animated)"
@@ -276,10 +279,12 @@ class Config(FaceswapConfig):
         self.add_item(
             section=section, title="container", datatype=str, default="mp4",
             choices=[ext.replace(".", "") for ext in _video_extensions],
+            gui_radio=True,
             info="Video container to use.")
         self.add_item(
             section=section, title="codec", datatype=str,
             choices=["libx264", "libx265"], default="libx264",
+            gui_radio=True,
             info="Video codec to use:"
                  "\n\t libx264: H.264. A widely supported and commonly used codec."
                  "\n\t libx265: H.265 / HEVC video encoder application library.")
@@ -298,6 +303,7 @@ class Config(FaceswapConfig):
             section=section, title="preset", datatype=str, default="medium",
             choices=["ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow",
                      "slower", "veryslow"],
+            gui_radio=True,
             info="A preset is a collection of options that will provide a certain encoding speed "
                  "to compression ratio.\nA slower preset will provide better compression "
                  "(compression is quality per filesize).\nUse the slowest preset that you have "

--- a/plugins/convert/color/_base.py
+++ b/plugins/convert/color/_base.py
@@ -16,11 +16,23 @@ def get_config(plugin_name):
 
 class Adjustment():
     """ Parent class for adjustments """
-    def __init__(self):
-        logger.debug("Initializing %s", self.__class__.__name__)
-        self.config = get_config(".".join(self.__module__.split(".")[-2:]))
+    def __init__(self, config=None):
+        logger.debug("Initializing %s: (config: %s)", self.__class__.__name__, config)
+        self.config = self.set_config(config)
         logger.debug("config: %s", self.config)
         logger.debug("Initialized %s", self.__class__.__name__)
+
+    def set_config(self, config):
+        """ Set the config to either global config or passed in config """
+        section = ".".join(self.__module__.split(".")[-2:])
+        if config is None:
+            retval = get_config(section)
+        else:
+            config.section = section
+            retval = config.config_dict
+            config.section = None
+        logger.debug("Config: %s", retval)
+        return retval
 
     def process(self, old_face, new_face, raw_mask):
         """ Override for specific color adjustment process """

--- a/plugins/convert/mask/_base.py
+++ b/plugins/convert/mask/_base.py
@@ -19,17 +19,29 @@ def get_config(plugin_name):
 
 class Adjustment():
     """ Parent class for adjustments """
-    def __init__(self, mask_type, output_size, predicted_available):
+    def __init__(self, mask_type, output_size, predicted_available, config=None):
         logger.debug("Initializing %s: (arguments: '%s', output_size: %s, "
-                     "predicted_available: %s)",
-                     self.__class__.__name__, mask_type, output_size, predicted_available)
-        self.config = get_config(".".join(self.__module__.split(".")[-2:]))
+                     "predicted_available: %s, config: %s)",
+                     self.__class__.__name__, mask_type, output_size, predicted_available, config)
+        self.config = self.set_config(config)
         logger.debug("config: %s", self.config)
         self.mask_type = self.get_mask_type(mask_type, predicted_available)
         self.dummy = np.zeros((output_size, output_size, 3), dtype='float32')
 
         self.skip = self.config.get("type", None) is None
         logger.debug("Initialized %s", self.__class__.__name__)
+
+    def set_config(self, config):
+        """ Set the config to either global config or passed in config """
+        section = ".".join(self.__module__.split(".")[-2:])
+        if config is None:
+            retval = get_config(section)
+        else:
+            config.section = section
+            retval = config.config_dict
+            config.section = None
+        logger.debug("Config: %s", retval)
+        return retval
 
     @staticmethod
     def get_mask_type(mask_type, predicted_available):

--- a/plugins/convert/mask/box_blend.py
+++ b/plugins/convert/mask/box_blend.py
@@ -13,8 +13,8 @@ class Mask(Adjustment):
         For actions that occur identically for each frame (e.g. blend_box), constants can
         be placed into self.func_constants to be compiled at launch, then referenced for
         each face. """
-    def __init__(self, mask_type, output_size, predicted_available=False):
-        super().__init__(mask_type, output_size, predicted_available)
+    def __init__(self, mask_type, output_size, predicted_available=False, config=None):
+        super().__init__(mask_type, output_size, predicted_available, config)
         self.mask = self.get_mask() if not self.skip else None
 
     def get_mask(self):

--- a/plugins/convert/mask/mask_blend.py
+++ b/plugins/convert/mask/mask_blend.py
@@ -10,8 +10,8 @@ from ._base import Adjustment, BlurMask, logger
 
 class Mask(Adjustment):
     """ Return the requested mask """
-    def __init__(self, mask_type, output_size, predicted_available):
-        super().__init__(mask_type, output_size, predicted_available)
+    def __init__(self, mask_type, output_size, predicted_available, config=None):
+        super().__init__(mask_type, output_size, predicted_available, config)
         self.do_erode = self.config.get("erosion", 0) != 0
         self.do_blend = self.config.get("type", None) is not None
 

--- a/plugins/convert/scaling/_base.py
+++ b/plugins/convert/scaling/_base.py
@@ -16,11 +16,25 @@ def get_config(plugin_name):
 
 class Adjustment():
     """ Parent class for scaling adjustments """
-    def __init__(self):
-        logger.debug("Initializing %s", self.__class__.__name__)
-        self.config = get_config(".".join(self.__module__.split(".")[-2:]))
+    def __init__(self, config=None):
+        logger.debug("Initializing %s: (config: %s)", self.__class__.__name__, config)
+        self.config = self.set_config(config)
         logger.debug("config: %s", self.config)
         logger.debug("Initialized %s", self.__class__.__name__)
+
+    def set_config(self, config):
+        """ Set the config to either global config or passed in config """
+        section = ".".join(self.__module__.split(".")[-2:])
+        if config is None:
+            logger.debug("Loading base config")
+            retval = get_config(section)
+        else:
+            logger.debug("Loading passed in config")
+            config.section = section
+            retval = config.config_dict
+            config.section = None
+        logger.debug("Config: %s", retval)
+        return retval
 
     def process(self, new_face):
         """ Override for specific scaling adjustment process """

--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -11,36 +11,37 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class PluginLoader():
     """ Plugin loader for extract, training and model tasks """
     @staticmethod
-    def get_detector(name):
+    def get_detector(name, disable_logging=False):
         """ Return requested detector plugin """
-        return PluginLoader._import("extract.detect", name)
+        return PluginLoader._import("extract.detect", name, disable_logging)
 
     @staticmethod
-    def get_aligner(name):
+    def get_aligner(name, disable_logging=False):
         """ Return requested detector plugin """
-        return PluginLoader._import("extract.align", name)
+        return PluginLoader._import("extract.align", name, disable_logging)
 
     @staticmethod
-    def get_model(name):
+    def get_model(name, disable_logging=False):
         """ Return requested model plugin """
-        return PluginLoader._import("train.model", name)
+        return PluginLoader._import("train.model", name, disable_logging)
 
     @staticmethod
-    def get_trainer(name):
+    def get_trainer(name, disable_logging=False):
         """ Return requested trainer plugin """
-        return PluginLoader._import("train.trainer", name)
+        return PluginLoader._import("train.trainer", name, disable_logging)
 
     @staticmethod
-    def get_converter(category, name):
+    def get_converter(category, name, disable_logging=False):
         """ Return the converter sub plugin """
-        return PluginLoader._import("convert.{}".format(category), name)
+        return PluginLoader._import("convert.{}".format(category), name, disable_logging)
 
     @staticmethod
-    def _import(attr, name):
+    def _import(attr, name, disable_logging):
         """ Import the plugin's module """
         name = name.replace("-", "_")
         ttl = attr.split(".")[-1].title()
-        logger.info("Loading %s from %s plugin...", ttl, name.title())
+        if not disable_logging:
+            logger.info("Loading %s from %s plugin...", ttl, name.title())
         attr = "model" if attr == "Trainer" else attr.lower()
         mod = ".".join(("plugins", attr, name))
         module = import_module(mod)

--- a/plugins/train/_config.py
+++ b/plugins/train/_config.py
@@ -64,7 +64,7 @@ class Config(FaceswapConfig):
                          ADDITIONAL_INFO)
         self.add_item(
             section=section, title="mask_type", datatype=str, default="facehull",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="coverage", datatype=float, default=100.0, rounding=1,
             min_max=(62.5, 100.0), info=COVERAGE_INFO)
@@ -80,7 +80,7 @@ class Config(FaceswapConfig):
                  "with a changed lowmem mode are not compatible with each other.")
         self.add_item(
             section=section, title="mask_type", datatype=str, default="dfl_full",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="coverage", datatype=float, default=62.5, rounding=1,
             min_max=(62.5, 100.0), info=COVERAGE_INFO)
@@ -92,7 +92,7 @@ class Config(FaceswapConfig):
                               "intermediate layers to try to better get details" + ADDITIONAL_INFO)
         self.add_item(
             section=section, title="mask_type", datatype=str, default="none",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="coverage", datatype=float, default=62.5, rounding=1,
             min_max=(62.5, 100.0), info=COVERAGE_INFO)
@@ -106,7 +106,7 @@ class Config(FaceswapConfig):
                               "software." + ADDITIONAL_INFO)
         self.add_item(
             section=section, title="mask_type", datatype=str, default="none",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="coverage", datatype=float, default=62.5, rounding=1,
             min_max=(62.5, 100.0), info=COVERAGE_INFO)
@@ -121,7 +121,7 @@ class Config(FaceswapConfig):
                  "with a changed lowmem mode are not compatible with each other.")
         self.add_item(
             section=section, title="mask_type", datatype=str, default="none",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="coverage", datatype=float, default=62.5, rounding=1,
             min_max=(62.5, 100.0), info=COVERAGE_INFO)
@@ -143,7 +143,7 @@ class Config(FaceswapConfig):
                  "the expense of VRAM")
         self.add_item(
             section=section, title="mask_type", datatype=str, default="none",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="nodes", datatype=int, default=1024, rounding=64,
             min_max=(512, 4096),
@@ -183,12 +183,8 @@ class Config(FaceswapConfig):
                               "model.\n"
                               "Requires about 6GB-8GB of VRAM (batchsize 8-16)." + ADDITIONAL_INFO)
         self.add_item(
-            section=section, title="dssim_loss", datatype=bool, default=True,
-            info="Use DSSIM for Loss rather than Mean Absolute Error\n"
-                 "May increase overall quality.")
-        self.add_item(
             section=section, title="mask_type", datatype=str, default="components",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="coverage", datatype=float, default=62.5, rounding=1,
             min_max=(62.5, 100.0),
@@ -243,7 +239,7 @@ class Config(FaceswapConfig):
                  "with a changed lowmem mode are not compatible with each other.")
         self.add_item(
             section=section, title="mask_type", datatype=str, default="none",
-            choices=MASK_TYPES, info=MASK_INFO)
+            choices=MASK_TYPES, gui_radio=True, info=MASK_INFO)
         self.add_item(
             section=section, title="coverage", datatype=float, default=62.5, rounding=1,
             min_max=(62.5, 100.0), info=COVERAGE_INFO)

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -446,13 +446,14 @@ class Predict():
             logger.error("%s does not exist.", self.args.model_dir)
             exit(1)
         trainer = self.get_trainer(model_dir)
-        model = PluginLoader.get_model(trainer)(model_dir, self.args.gpus, predict=True)
+        gpus = 1 if not hasattr(self.args, "gpus") else self.args.gpus
+        model = PluginLoader.get_model(trainer)(model_dir, gpus, predict=True)
         logger.debug("Loaded Model")
         return model
 
     def get_trainer(self, model_dir):
         """ Return the trainer name if provided, or read from state file """
-        if self.args.trainer:
+        if hasattr(self.args, "trainer") and self.args.trainer:
             logger.debug("Trainer name provided: '%s'", self.args.trainer)
             return self.args.trainer
 

--- a/scripts/fsmedia.py
+++ b/scripts/fsmedia.py
@@ -210,11 +210,31 @@ class Images():
             yield filename, frame
         cap.release()
 
-    @staticmethod
-    def load_one_image(filename):
-        """ load requested image """
+    def load_one_image(self, filename):
+        """ load requested image
+            pass in the filename if loading from images
+            pass in the frame number (int) if loading from video
+        """
         logger.trace("Loading image: '%s'", filename)
-        return cv2.imread(filename)  # pylint: disable=no-member
+        if self.is_video:
+            retval = self.load_one_video_frame(filename)
+        else:
+            retval = cv2.imread(filename)  # pylint: disable=no-member
+        return retval
+
+    def load_one_video_frame(self, frame_no):
+        """ Load a single frame from a video file """
+        logger.trace("Loading video frame: %s", frame_no)
+        vidname = os.path.splitext(os.path.basename(self.args.input_dir))[0]
+        cap = cv2.VideoCapture(self.args.input_dir)  # pylint: disable=no-member
+        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_no - 1)  # pylint: disable=no-member
+        ret, frame = cap.read()
+        if not ret:
+            logger.error("Unable to read from %s from video %s", frame_no, self.args.input_dir)
+            exit(1)
+        filename = "{}_{:06d}.png".format(vidname, frame_no)
+        cap.release()
+        return filename, frame
 
 
 class PostProcess():

--- a/scripts/fsmedia.py
+++ b/scripts/fsmedia.py
@@ -211,13 +211,15 @@ class Images():
         cap.release()
 
     def load_one_image(self, filename):
-        """ load requested image
-            pass in the filename if loading from images
-            pass in the frame number (int) if loading from video
-        """
+        """ load requested image """
         logger.trace("Loading image: '%s'", filename)
         if self.is_video:
-            retval = self.load_one_video_frame(filename)
+            if filename.isdigit():
+                frame_no = filename
+            else:
+                frame_no = os.path.splitext(filename)[0][filename.rfind("_") + 1:]
+                logger.trace("Extracted frame_no %s from filename '%s'", frame_no, filename)
+            retval = self.load_one_video_frame(int(frame_no))
         else:
             retval = cv2.imread(filename)  # pylint: disable=no-member
         return retval
@@ -225,16 +227,14 @@ class Images():
     def load_one_video_frame(self, frame_no):
         """ Load a single frame from a video file """
         logger.trace("Loading video frame: %s", frame_no)
-        vidname = os.path.splitext(os.path.basename(self.args.input_dir))[0]
         cap = cv2.VideoCapture(self.args.input_dir)  # pylint: disable=no-member
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_no - 1)  # pylint: disable=no-member
         ret, frame = cap.read()
         if not ret:
             logger.error("Unable to read from %s from video %s", frame_no, self.args.input_dir)
             exit(1)
-        filename = "{}_{:06d}.png".format(vidname, frame_no)
         cap.release()
-        return filename, frame
+        return frame
 
 
 class PostProcess():

--- a/tools.py
+++ b/tools.py
@@ -3,7 +3,7 @@
 import sys
 # Importing the various tools
 import tools.cli as cli
-from lib.cli import FullHelpArgumentParser, GuiArgs
+from lib.cli import FullHelpArgumentParser
 
 # Python version check
 if sys.version_info[0] < 3:
@@ -12,35 +12,34 @@ if sys.version_info[0] == 3 and sys.version_info[1] < 2:
     raise Exception("This program requires at least python3.2")
 
 
-def bad_args(args):
+def bad_args(args):  # pylint:disable=unused-argument
     """ Print help on bad arguments """
     PARSER.print_help()
     exit(0)
 
 
 if __name__ == "__main__":
-    _tools_warning = "Please backup your data and/or test the tool you want "
-    _tools_warning += "to use with a smaller data set to make sure you "
-    _tools_warning += "understand how it works."
-    print(_tools_warning)
+    _TOOLS_WARNING = "Please backup your data and/or test the tool you want "
+    _TOOLS_WARNING += "to use with a smaller data set to make sure you "
+    _TOOLS_WARNING += "understand how it works."
+    print(_TOOLS_WARNING)
 
     PARSER = FullHelpArgumentParser()
     SUBPARSER = PARSER.add_subparsers()
     ALIGN = cli.AlignmentsArgs(SUBPARSER,
                                "alignments",
-                               "This command lets you perform various tasks "
-                               "pertaining to an alignments file.")
+                               "This command lets you perform various tasks pertaining to an "
+                               "alignments file.")
+    CONVSET = cli.ConvsetArgs(SUBPARSER,
+                              "convset",
+                              "This command allows you to preview swaps to tweak convert "
+                              "settings.")
     EFFMPEG = cli.EffmpegArgs(SUBPARSER,
                               "effmpeg",
-                              "This command allows you to easily execute "
-                              "common ffmpeg tasks.")
+                              "This command allows you to easily execute common ffmpeg tasks.")
     SORT = cli.SortArgs(SUBPARSER,
                         "sort",
-                        "This command lets you sort images using various "
-                        "methods.")
-    GUI = GuiArgs(SUBPARSER,
-                  "gui",
-                  "Launch the Faceswap Tools Graphical User Interface.")
+                        "This command lets you sort images using various methods.")
     PARSER.set_defaults(func=bad_args)
     ARGUMENTS = PARSER.parse_args()
     ARGUMENTS.func(ARGUMENTS)

--- a/tools.py
+++ b/tools.py
@@ -30,8 +30,8 @@ if __name__ == "__main__":
                                "alignments",
                                "This command lets you perform various tasks pertaining to an "
                                "alignments file.")
-    CONVSET = cli.ConvsetArgs(SUBPARSER,
-                              "convset",
+    PREVIEW = cli.PreviewArgs(SUBPARSER,
+                              "preview",
                               "This command allows you to preview swaps to tweak convert "
                               "settings.")
     EFFMPEG = cli.EffmpegArgs(SUBPARSER,

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -152,8 +152,8 @@ class AlignmentsArgs(FaceSwapArgs):
         return argument_list
 
 
-class ConvsetArgs(FaceSwapArgs):
-    """ Class to parse the command line arguments for ConvSet (Convert Settings) tool """
+class PreviewArgs(FaceSwapArgs):
+    """ Class to parse the command line arguments for Preview (Convert Settings) tool """
     def get_argument_list(self):
 
         argument_list = list()

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """ Command Line Arguments for tools """
 from lib.cli import FaceSwapArgs
-from lib.cli import (ContextFullPaths, DirFullPaths, FileFullPaths, FilesFullPaths,
-                     SaveFileFullPaths, Radio, Slider)
+from lib.cli import (ContextFullPaths, DirOrFileFullPaths, DirFullPaths, FileFullPaths,
+                     FilesFullPaths, SaveFileFullPaths, Radio, Slider)
 from lib.utils import _image_extensions
 
 
@@ -149,6 +149,42 @@ class AlignmentsArgs(FaceSwapArgs):
                               "help": "Enable this option if manual "
                                       "alignments window is closing "
                                       "instantly. (Manual only)"})
+        return argument_list
+
+
+class ConvsetArgs(FaceSwapArgs):
+    """ Class to parse the command line arguments for ConvSet (Convert Settings) tool """
+    def get_argument_list(self):
+
+        argument_list = list()
+        argument_list.append({"opts": ("-i", "--input-dir"),
+                              "action": DirOrFileFullPaths,
+                              "filetypes": "video",
+                              "dest": "input_dir",
+                              "required": True,
+                              "help": "Input directory or video. Either a directory containing "
+                                      "the image files you wish to process or path to a video "
+                                      "file."})
+        argument_list.append({"opts": ("-al", "--alignments"),
+                              "action": FileFullPaths,
+                              "filetypes": "alignments",
+                              "type": str,
+                              "dest": "alignments_path",
+                              "help": "Path to the alignments file for the input, if not at the "
+                                      "default location"})
+        argument_list.append({"opts": ("-m", "--model-dir"),
+                              "action": DirFullPaths,
+                              "dest": "model_dir",
+                              "required": True,
+                              "help": "Model directory. A directory containing the trained model "
+                                      "you wish to process."})
+        argument_list.append({"opts": ("-s", "--swap-model"),
+                              "action": "store_true",
+                              "dest": "swap_model",
+                              "default": False,
+                              "help": "Swap the model. Instead of A -> B, "
+                                      "swap B -> A"})
+
         return argument_list
 
 

--- a/tools/convset.py
+++ b/tools/convset.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+""" Tool to preview swaps and tweak the config prior to running a convert
+
+Sketch:
+
+    - predict 4 random faces (full set distribution)
+    - keep mask + face separate
+    - show faces swapped into padded square of final image
+    - live update on settings change
+    - apply + save config
+"""
+import logging
+import random
+
+import cv2
+import numpy as np
+
+from lib.faces_detect import DetectedFace
+from lib.utils import set_system_verbosity
+from lib.queue_manager import queue_manager
+from scripts.fsmedia import Alignments, Images
+from scripts.convert import Predict
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class Convset():
+    """ Loads up 4 semi-random face swaps and displays them, cropped, in place in the final frame.
+        Allows user to live tweak settings, before saving the final config to
+        ./config/convert.ini """
+
+    def __init__(self, arguments):
+        logger.debug("Initializing %s: (arguments: '%s'", self.__class__.__name__, arguments)
+        self.args = arguments
+        self.faces = TestSet(arguments)
+        self.display = FacesDisplay(self.faces.faces_source, self.faces.faces_predicted, 256)
+        set_system_verbosity(self.args.loglevel)
+        logger.debug("Initialized %s", self.__class__.__name__)
+
+    def process(self):
+        """ The convset process """
+        cv2.imshow("test", self.display.image)
+        cv2.waitKey()
+        exit(0)
+
+
+class TestSet():
+    """ Holds 4 random test faces """
+
+    def __init__(self, arguments):
+        logger.debug("Initializing %s: (arguments: '%s'", self.__class__.__name__, arguments)
+        self.sample_size = 4
+
+        self.images = Images(arguments)
+        self.alignments = Alignments(arguments,
+                                     is_extract=False,
+                                     input_is_video=self.images.is_video)
+        self.queues = {"predict_in": queue_manager.get_queue("convset_predict_in")}
+        self.indices = self.get_indices()
+        self.predictor = Predict(self.queues["predict_in"], 4, arguments)
+
+        self.selected_frames = list()
+        self.faces_source = None
+        self.faces_predicted = None
+
+        self.generate()
+        logger.debug("Initialized %s", self.__class__.__name__)
+
+    @property
+    def random_choice(self):
+        """ Return for random indices from the indices group """
+        retval = [random.choice(indices) for indices in self.indices]
+        logger.debug(retval)
+        return retval
+
+    @property
+    def queue_predict_in(self):
+        """ Predict in queue """
+        return self.queues["predict_in"]
+
+    @property
+    def queue_predict_out(self):
+        """ Predict in queue """
+        return self.predictor.out_queue
+
+    def get_indices(self):
+        """ Returns a list of 'self.sample_size' evenly sized partition indices
+            pertaining to the file file list """
+        # Remove start and end values to get a list divisible by self.sample_size
+        crop = self.images.images_found % self.sample_size
+        top_tail = list(range(self.images.images_found))[crop // 2:- (crop - (crop // 2))]
+        # Partition the indices
+        size = len(top_tail)
+        retval = [top_tail[start:start + size // self.sample_size]
+                  for start in range(0, size, size // self.sample_size)]
+        logger.debug(retval)
+        return retval
+
+    def generate(self):
+        """ Generate a random test set """
+        self.load_frames()
+        faces = self.predict()
+        self.faces_source = np.array([face["detected_faces"][0].reference_face for face in faces])
+        self.faces_predicted = np.array([face["swapped_faces"][0] for face in faces])
+
+    def load_frames(self):
+        """ Load 'self.sample_size' random frames """
+        # TODO Only read frames we need rather than all of them and discarding
+        # TODO Handle frames without faces
+        self.selected_frames = list()
+        selection = self.random_choice
+        for idx, item in enumerate(self.images.load()):
+            if idx not in selection:
+                continue
+            filename, image = item
+            face = self.alignments.get_faces_in_frame(filename)[0]
+            detected_face = DetectedFace()
+            detected_face.from_alignment(face, image=image)
+            self.selected_frames.append({"filename": filename,
+                                         "image": image,
+                                         "detected_faces": [detected_face]})
+        logger.debug("Selected frames: %s", [frame["filename"] for frame in self.selected_frames])
+
+    def predict(self):
+        """ Predict from the loaded frames """
+        for frame in self.selected_frames:
+            self.queue_predict_in.put(frame)
+        self.queue_predict_in.put("EOF")
+        faces = list()
+        while True:
+            item = self.queue_predict_out.get()
+            if item == "EOF":
+                break
+            faces.append(item)
+        return faces
+
+
+class FacesDisplay():
+    """ Compiled faces into a single image """
+    def __init__(self, source_faces, predicted_faces, size):
+        logger.trace("Initializing %s: (source_faces shape: %s, predicted_faces shape: %s, size: "
+                     "%s)",
+                     self.__class__.__name__, source_faces.shape, predicted_faces.shape, size)
+        self.size = size
+        self.faces_src = source_faces
+        self.faces_pred = predicted_faces
+
+        self.image = self.build_faces_image()
+        logger.trace("Initialized %s", self.__class__.__name__)
+
+    def build_faces_image(self):
+        """ Display associated faces """
+        assert self.faces_src.shape[0] == self.faces_pred.shape[0]
+        total_faces = self.faces_src.shape[0]
+        logger.trace("Building faces panel. (total_faces: %s", total_faces)
+
+        source = np.hstack([self.normalize_thumbnail(face) for face in self.faces_src])
+        mask = np.hstack([self.normalize_thumbnail(face[:, :, -1]) for face in self.faces_pred])
+        predicted = np.hstack([self.normalize_thumbnail(face[:, :, :3])
+                              for face in self.faces_pred])
+        image = np.vstack((source, mask, predicted))
+        logger.debug("source row shape: %s, mask row shape: %s, predicted row shape: %s, final "
+                     "image shape: %s", source.shape, mask.shape, predicted.shape, image.shape)
+        return image
+
+    def normalize_thumbnail(self, image):
+        """ Resize image and draw border """
+        if image.shape[0] < self.size:
+            interpolation = cv2.INTER_CUBIC  # pylint:disable=no-member
+        else:
+            interpolation = cv2.INTER_AREA  # pylint:disable=no-member
+        output = cv2.resize(image,  # pylint:disable=no-member
+                            (self.size, self.size),
+                            interpolation=interpolation)
+        cv2.rectangle(output,    # pylint:disable=no-member
+                      (0, 0),
+                      (self.size - 1, self.size - 1),
+                      (255, 255, 255),
+                      1)
+        if output.ndim == 2:
+            output = np.expand_dims(output, axis=-1)
+        if output.shape[-1] == 1:
+            output = np.tile(output, 3)
+        output = np.clip(output, 0.0, 255.0)
+        return output

--- a/tools/convset.py
+++ b/tools/convset.py
@@ -11,15 +11,21 @@ Sketch:
 """
 import logging
 import random
+import sys
+import os
 
 import cv2
 import numpy as np
 
+from lib.cli import ConvertArgs
+from lib.convert import Converter
 from lib.faces_detect import DetectedFace
 from lib.utils import set_system_verbosity
 from lib.queue_manager import queue_manager
 from scripts.fsmedia import Alignments, Images
 from scripts.convert import Predict
+
+from plugins.convert._config import Config
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -31,39 +37,124 @@ class Convset():
 
     def __init__(self, arguments):
         logger.debug("Initializing %s: (arguments: '%s'", self.__class__.__name__, arguments)
-        self.args = arguments
-        self.faces = TestSet(arguments)
-        self.display = FacesDisplay(self.faces.faces_source, self.faces.faces_predicted, 256)
-        set_system_verbosity(self.args.loglevel)
+        set_system_verbosity(arguments.loglevel)
+        self.queues = {"patch_in": queue_manager.get_queue("convset_patch_in"),
+                       "patch_out": queue_manager.get_queue("convset_patch_out")}
+
+        self.faces = TestSet(arguments, self.queue_patch_in)
+        self.arguments = self.generate_converter_arguments(arguments)
+        self.configs = self.get_configs()
+
+        print(self.arguments)
+        print(self.configs)
+
+        self.converter = Converter(output_dir=None,
+                                   output_size=self.faces.predictor.output_size,
+                                   output_has_mask=self.faces.predictor.has_predicted_mask,
+                                   draw_transparent=False,
+                                   pre_encode=None,
+                                   arguments=self.arguments)
+
+        # self.display = FacesDisplay(self.faces.faces_source, self.faces.faces_predicted, 256)
+
         logger.debug("Initialized %s", self.__class__.__name__)
+
+    @property
+    def queue_patch_in(self):
+        """ Patch in queue """
+        return self.queues["patch_in"]
+
+    @property
+    def queue_patch_out(self):
+        """ Patch out queue """
+        return self.queues["patch_out"]
+
+    @staticmethod
+    def generate_converter_arguments(arguments):
+        """ Get the default converter arguments """
+        converter_arguments = ConvertArgs(None, "convert").get_optional_arguments()
+        for item in converter_arguments:
+            value = item.get("default", None)
+            # Skip options without a default value
+            if value is None:
+                continue
+            option = item.get("dest", item["opts"][1].replace("--", ""))
+            # Skip options already in arguments
+            if hasattr(arguments, option):
+                continue
+            # Add option to arguments
+            setattr(arguments, option, value)
+        logger.debug(arguments)
+        return arguments
 
     def process(self):
         """ The convset process """
+        self.faces.generate()
+        self.converter.process(self.queue_patch_in, self.queue_patch_out)
+        idx = 0
+        while idx < self.faces.sample_size:
+            logger.debug("Patching image %s of %s", idx + 1, self.faces.sample_size)
+            item = self.queue_patch_out.get()
+            self.faces.selected_frames[idx]["swapped_image"] = item[1]
+            logger.debug("Patched image %s of %s", idx + 1, self.faces.sample_size)
+            idx += 1
+        logger.debug("Patched faces")
+        for frame in self.faces.selected_frames:
+            print(frame["filename"],
+                  frame["image"].shape,
+                  frame["source_face"].shape,
+                  frame["swapped_face"].shape,
+                  frame["swapped_image"].shape)
+        print([key for key in self.faces.selected_frames[0].keys()])
+        exit(0)
+
         cv2.imshow("test", self.display.image)
         cv2.waitKey()
         exit(0)
+
+    def get_configs(self):
+        """ Return all of the convert configs """
+        modules = self.get_modules()
+        configs = {".".join((key, plugin)): Config(".".join((key, plugin)))
+                   for key, val in modules.items()
+                   for plugin in val}
+        logger.debug(configs)
+        return configs
+
+    @staticmethod
+    def get_modules():
+        """ Return all available convert plugins """
+        root_path = os.path.abspath(os.path.dirname(sys.argv[0]))
+        plugins_path = os.path.join(root_path, "plugins", "convert")
+        modules = {os.path.basename(dirpath): [os.path.splitext(module)[0]
+                                               for module in filenames
+                                               if os.path.splitext(module)[1] == ".py"
+                                               and module not in ("__init__.py", "_base.py")]
+                   for dirpath, _, filenames in os.walk(plugins_path)
+                   if os.path.basename(dirpath) not in ("convert", "__pycache__", "writer")}
+        logger.debug("Modules: %s", modules)
+        return modules
 
 
 class TestSet():
     """ Holds 4 random test faces """
 
-    def __init__(self, arguments):
-        logger.debug("Initializing %s: (arguments: '%s'", self.__class__.__name__, arguments)
+    def __init__(self, arguments, patch_queue):
+        logger.debug("Initializing %s: (arguments: '%s', patch_queue: %s)",
+                     self.__class__.__name__, arguments, patch_queue)
         self.sample_size = 4
 
         self.images = Images(arguments)
         self.alignments = Alignments(arguments,
                                      is_extract=False,
                                      input_is_video=self.images.is_video)
-        self.queues = {"predict_in": queue_manager.get_queue("convset_predict_in")}
+        self.queues = {"predict_in": queue_manager.get_queue("convset_predict_in"),
+                       "patch_in": patch_queue}
         self.indices = self.get_indices()
         self.predictor = Predict(self.queues["predict_in"], 4, arguments)
 
         self.selected_frames = list()
-        self.faces_source = None
-        self.faces_predicted = None
 
-        self.generate()
         logger.debug("Initialized %s", self.__class__.__name__)
 
     @property
@@ -83,6 +174,11 @@ class TestSet():
         """ Predict in queue """
         return self.predictor.out_queue
 
+    @property
+    def queue_patch_in(self):
+        """ Patch in queue """
+        return self.queues["patch_in"]
+
     def get_indices(self):
         """ Returns a list of 'self.sample_size' evenly sized partition indices
             pertaining to the file file list """
@@ -99,9 +195,7 @@ class TestSet():
     def generate(self):
         """ Generate a random test set """
         self.load_frames()
-        faces = self.predict()
-        self.faces_source = np.array([face["detected_faces"][0].reference_face for face in faces])
-        self.faces_predicted = np.array([face["swapped_faces"][0] for face in faces])
+        self.predict()
 
     def load_frames(self):
         """ Load 'self.sample_size' random frames """
@@ -126,13 +220,20 @@ class TestSet():
         for frame in self.selected_frames:
             self.queue_predict_in.put(frame)
         self.queue_predict_in.put("EOF")
-        faces = list()
-        while True:
+        idx = 0
+        while idx < self.sample_size:
+            logger.debug("Predicting face %s of %s", idx + 1, self.sample_size)
             item = self.queue_predict_out.get()
             if item == "EOF":
+                logger.debug("Received EOF")
                 break
-            faces.append(item)
-        return faces
+            self.queue_patch_in.put(item)
+            self.selected_frames[idx]["source_face"] = item["detected_faces"][0].reference_face
+            self.selected_frames[idx]["swapped_face"] = item["swapped_faces"][0]
+            logger.debug("Predicted face %s of %s", idx + 1, self.sample_size)
+            idx += 1
+        self.queue_patch_in.put("EOF")
+        logger.debug("Predicted faces")
 
 
 class FacesDisplay():
@@ -157,7 +258,7 @@ class FacesDisplay():
         source = np.hstack([self.normalize_thumbnail(face) for face in self.faces_src])
         mask = np.hstack([self.normalize_thumbnail(face[:, :, -1]) for face in self.faces_pred])
         predicted = np.hstack([self.normalize_thumbnail(face[:, :, :3])
-                              for face in self.faces_pred])
+                               for face in self.faces_pred])
         image = np.vstack((source, mask, predicted))
         logger.debug("source row shape: %s, mask row shape: %s, predicted row shape: %s, final "
                      "image shape: %s", source.shape, mask.shape, predicted.shape, image.shape)

--- a/tools/convset.py
+++ b/tools/convset.py
@@ -43,7 +43,6 @@ class Convset():
 
     def __init__(self, arguments):
         logger.debug("Initializing %s: (arguments: '%s'", self.__class__.__name__, arguments)
-        queue_manager.debug_monitor(2)
         set_system_verbosity(arguments.loglevel)
         self.queues = {"patch_in": queue_manager.get_queue("convset_patch_in"),
                        "patch_out": queue_manager.get_queue("convset_patch_out")}

--- a/tools/preview.py
+++ b/tools/preview.py
@@ -91,7 +91,7 @@ class Preview():
     def set_geometry(self):
         """ Set GUI geometry """
         self.root.tk.call("tk", "scaling", self.scaling)
-        width = int(960 * self.scaling)
+        width = int(940 * self.scaling)
         height = int(600 * self.scaling)
         logger.debug("Geometry: %sx%s", width, height)
         self.root.geometry("{}x{}+80+80".format(str(width), str(height)))


### PR DESCRIPTION
Currently in Beta. Please report bugs.

This tool is used to tweak convert settings prior to convert. It selects five semi-random frames from the source video and displays the source faces in the top row, with the convert settings applied to the bottom row.

The faces are selected by splitting the video into 5 even pools and then selecting a random face from each of these pools to give a fairly even split across the video.

To launch:
```python tools.py preview -i <path_to_source_video> -m <path_to_model_folder> -a [optional] <path_to_alignments_file> -s [swap model] ```

It can also be launched from the tools tab in the GUI.

The preview will live update as settings change. The final config can then be saved (either as a whole, or for just the section you are working on) ready for convert.

![convset](https://user-images.githubusercontent.com/36920800/58578325-6f663d80-8240-11e9-8ce4-ded2d024fb58.jpg)

**TODO:**
~GUI Integration~ (Abandoned. Too much work for too little benefit)
~Final testing/code cleanup~