### PR TITLE
Bug fix: export alignement.json file with save-interval option.

### DIFF
--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -191,7 +191,7 @@ class Extract():
                 if self.extractor.final_pass:
                     self.output_processing(faces, align_eyes, size, filename)
                     self.output_faces(filename, faces)
-                    if self.save_interval and idx + 1 % self.save_interval == 0:
+                    if self.save_interval and (idx + 1) % self.save_interval == 0:
                         self.alignments.save()
                 else:
                     del faces["image"]


### PR DESCRIPTION
One-liner fix. The modulo operation has priority over the addition. Because parentheses were missing in the condition, the condition was never met. Because of this, even if we run the extract script with the `save-interval` option, the alignements.json file is never generated.

Fixes https://github.com/deepfakes/faceswap/issues/739