### PR TITLE
Ubuntu 19.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,8 +140,8 @@ class Environment():
         if not (self.py_version[0].split(".")[0] == "3"
                 and self.py_version[0].split(".")[1] in ("3", "4", "5", "6", "7")
                 and self.py_version[1] == "64bit"):
-            self.output.error("Please run this script with Python version 3.3, 3.4, 3.5, 3.6 or 3.7 "
-                              "64bit and try again.")
+            self.output.error("Please run this script with Python version 3.3, 3.4, 3.5, 3.6 "
+                              "or 3.7 64bit and try again.")
             exit(1)
 
     def output_runtime_info(self):
@@ -471,7 +471,8 @@ class Checks():
     @staticmethod
     def cudnn_checkfiles_linux():
         """ Return the checkfile locations for linux """
-        chk = os.popen("for i in `echo '' | gcc -v -E - 2>&1 | grep '^ /[^ ]\+$'`; do ls $i/cudnn_v*.h 2>/dev/null; done").readline()
+        chk = os.popen("for i in `echo '' | gcc -v -E - 2>&1 | grep '^ /[^ ]\\+$'`; "
+                       "do ls $i/cudnn_v*.h 2>/dev/null; done").readline()
         cudnn_checkfiles = [chk.strip()]
 
         return cudnn_checkfiles

--- a/setup.py
+++ b/setup.py
@@ -138,9 +138,9 @@ class Environment():
         self.output.info("Installed Python: {0} {1}".format(self.py_version[0],
                                                             self.py_version[1]))
         if not (self.py_version[0].split(".")[0] == "3"
-                and self.py_version[0].split(".")[1] in ("3", "4", "5", "6")
+                and self.py_version[0].split(".")[1] in ("3", "4", "5", "6", "7")
                 and self.py_version[1] == "64bit"):
-            self.output.error("Please run this script with Python version 3.3, 3.4, 3.5 or 3.6 "
+            self.output.error("Please run this script with Python version 3.3, 3.4, 3.5, 3.6 or 3.7 "
                               "64bit and try again.")
             exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -471,13 +471,9 @@ class Checks():
     @staticmethod
     def cudnn_checkfiles_linux():
         """ Return the checkfile locations for linux """
-        chk = os.popen("ldconfig -p | grep -P \"libcudnn.so.\\d+\" | head -n 1").read()
-        chk = chk.strip().replace("libcudnn.so.", "")
-        cudnn_vers = chk[0]
-        cudnn_path = chk[chk.find("=>") + 3:chk.find("libcudnn") - 1]
-        cudnn_path = cudnn_path.replace("lib", "include")
-        cudnn_checkfiles = [os.path.join(cudnn_path, "cudnn_v{}.h".format(cudnn_vers)),
-                            os.path.join(cudnn_path, "cudnn.h")]
+        chk = os.popen("for i in `echo '' | gcc -v -E - 2>&1 | grep '^ /[^ ]\+$'`; do ls $i/cudnn_v*.h 2>/dev/null; done").readline()
+        cudnn_checkfiles = [chk.strip()]
+
         return cudnn_checkfiles
 
     def cudnn_checkfiles_windows(self):


### PR DESCRIPTION
Attempting to make faceswap run on Ubuntu 19.04:

- Python 3.7 explicitly allowed (seems to work)
- nVidia's .deb package installs includes and libs of cudnn into different directories - replaced the original code with a query for gcc's includes (also not ideal, but it seems to be more reliable)

Please test before merging - I believe this code is generic and should not break on other distros, but haven't tested on anything non-debian-based.