### PR TITLE
Do not `rename` files after `remove-faces` action

### DIFF
--- a/tools/lib_alignments/jobs.py
+++ b/tools/lib_alignments/jobs.py
@@ -718,10 +718,6 @@ class RemoveAlignments():
         logger.info("%s alignment(s) were removed from alignments file", del_count)
         self.alignments.save()
 
-        if self.type == "faces":
-            rename = Rename(self.alignments, None, self.items)
-            rename.process()
-
     def remove_frames(self, frame):
         """ Process to remove frames from an alignments file """
         if frame in self.items:


### PR DESCRIPTION
After a long sorting job, it's kind of annoying that `remove-faces` _also_ does the `rename` action for you. I might want to keep my files sorted after I clean up my alignments file with `remove-faces`. So I think it's better if we manually trigger `rename` action when we decide it's time to remove the sorting.