### PR TITLE
Catch 0 size images earlier + plaidml version + minor gui update

### DIFF
--- a/lib/gui/display_command.py
+++ b/lib/gui/display_command.py
@@ -191,7 +191,7 @@ class GraphDisplay(DisplayOptionalPage):  # pylint: disable=too-many-ancestors
                                 command=lambda: tk_var.set(True))
         btnrefresh.pack(padx=2, side=tk.RIGHT)
         Tooltip(btnrefresh,
-                text="Graph updates every 100 iterations. Click to refresh now.",
+                text="Graph updates at every model save. Click to refresh now.",
                 wraplength=200)
         logger.debug("Added refresh option")
 

--- a/plugins/extract/detect/_base.py
+++ b/plugins/extract/detect/_base.py
@@ -147,6 +147,13 @@ class Detector():
             logger.trace("Item out: %s", {key: val
                                           for key, val in output.items()
                                           if key != "image"})
+            # Prevent zero size faces
+            iheight, iwidth = output["image"].shape[:2]
+            output["detected_faces"] = [
+                f for f in output.get("detected_faces", list())
+                if f["right"] > 0 and f["left"] < iwidth
+                and f["bottom"] > 0 and f["top"] < iheight
+            ]
             if self.min_size > 0 and output.get("detected_faces", None):
                 output["detected_faces"] = self.filter_small_faces(output["detected_faces"])
         else:

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ class Environment():
     def update_amd_dep(self):
         """ Update amd dependency for AMD cards """
         if self.enable_amd:
-            self.required_packages.append("plaidml-keras==0.6.3")
+            self.required_packages.append("plaidml-keras==0.6.4")
 
 
 class Output():


### PR DESCRIPTION
- Catches detected faces which are outside of the image earlier
- Increases plaidml version required to 0.6.4 as it seem to work fine
- Updated tooltip for "reload now" button in graph tab