### PR TITLE
Ensure frames are only counted once

### DIFF
--- a/scripts/fsmedia.py
+++ b/scripts/fsmedia.py
@@ -139,10 +139,10 @@ class Images():
         self.args = arguments
         self.is_video = self.check_input_folder()
         self.input_images = self.get_input_images()
+        self.images_found = self.count_images()
         logger.debug("Initialized %s", self.__class__.__name__)
 
-    @property
-    def images_found(self):
+    def count_images(self):
         """ Number of images or frames """
         if self.is_video:
             retval = int(count_frames_and_secs(self.args.input_dir)[0])

--- a/tools/lib_alignments/media.py
+++ b/tools/lib_alignments/media.py
@@ -97,6 +97,7 @@ class MediaLoader():
         self.vid_reader = self.check_input_folder()
         self.file_list_sorted = self.sorted_items()
         self.items = self.load_items()
+        self.count = self.count_frames()
         logger.verbose("%s items loaded", self.count)
         logger.debug("Initialized %s", self.__class__.__name__)
 
@@ -105,8 +106,7 @@ class MediaLoader():
         """ Return whether source is a video or not """
         return self.vid_reader is not None
 
-    @property
-    def count(self):
+    def count_frames(self):
         """ Number of faces or frames """
         if self.is_video:
             retval = int(count_frames_and_secs(self.folder)[0])


### PR DESCRIPTION
Ensure video frames are only counted once.
Previous this was done in properties which where called multiple times.

Possible fixes the hanging problem and seem to solve occasionally wrong calculated frame count.
We should investigate why it sometimes calculated the wrong frame count at all, but for now this will make things better at least.