### PR TITLE
Optimized numpy functions in Converter

### DIFF
--- a/lib/convert.py
+++ b/lib/convert.py
@@ -12,7 +12,6 @@ from plugins.plugin_loader import PluginLoader
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-
 class Converter():
     """ Swap a source face with a target """
     def __init__(self, output_dir, output_size, output_has_mask,
@@ -78,31 +77,32 @@ class Converter():
         logger.debug("Starting convert process. (in_queue: %s, out_queue: %s, completion_queue: "
                      "%s)", in_queue, out_queue, completion_queue)
         while True:
-            item = in_queue.get()
-            if item == "EOF":
+            items = in_queue.get()
+            if items == "EOF":
                 logger.debug("EOF Received")
                 logger.debug("Patch queue finished")
                 # Signal EOF to other processes in pool
                 logger.debug("Putting EOF back to in_queue")
-                in_queue.put(item)
+                in_queue.put(items)
                 break
-            logger.trace("Patch queue got: '%s'", item["filename"])
 
-            try:
-                image = self.patch_image(item)
-            except Exception as err:  # pylint: disable=broad-except
-                # Log error and output original frame
-                logger.error("Failed to convert image: '%s'. Reason: %s",
-                             item["filename"], str(err))
-                image = item["image"]
-                # UNCOMMENT THIS CODE BLOCK TO PRINT TRACEBACK ERRORS
-                # import sys
-                # import traceback
-                # exc_info = sys.exc_info()
-                # traceback.print_exception(*exc_info)
+            for item in items:
+                logger.trace("Patch queue got: '%s'", item["filename"])
+                try:
+                    image = self.patch_image(item)
+                except Exception as err:  # pylint: disable=broad-except
+                    # Log error and output original frame
+                    logger.error("Failed to convert image: '%s'. Reason: %s",
+                                 item["filename"], str(err))
+                    image = item["image"]
+                    # UNCOMMENT THIS CODE BLOCK TO PRINT TRACEBACK ERRORS
+                    # import sys
+                    # import traceback
+                    # exc_info = sys.exc_info()
+                    # traceback.print_exception(*exc_info)
 
-            logger.trace("Out queue put: %s", item["filename"])
-            out_queue.put((item["filename"], image))
+                logger.trace("Out queue put: %s", item["filename"])
+                out_queue.put((item["filename"], image))
         logger.debug("Completed convert process")
         # Signal that this process has finished
         if completion_queue is not None:
@@ -112,10 +112,15 @@ class Converter():
         """ Patch the image """
         logger.trace("Patching image: '%s'", predicted["filename"])
         frame_size = (predicted["image"].shape[1], predicted["image"].shape[0])
-        new_image = self.get_new_image(predicted, frame_size)
-        patched_face = self.post_warp_adjustments(predicted, new_image)
+        new_image, background = self.get_new_image(predicted, frame_size)
+        patched_face = self.post_warp_adjustments(background, new_image)
         patched_face = self.scale_image(patched_face)
-        patched_face = np.rint(patched_face * 255.0).astype("uint8")
+        patched_face *= 255.0
+        patched_face = np.rint(
+            patched_face,
+            out=np.empty(patched_face.shape, dtype="uint8"),
+            casting='unsafe'
+        )
         if self.writer_pre_encode is not None:
             patched_face = self.writer_pre_encode(patched_face)
         logger.trace("Patched image: '%s'", predicted["filename"])
@@ -126,10 +131,10 @@ class Converter():
         logger.trace("Getting: (filename: '%s', faces: %s)",
                      predicted["filename"], len(predicted["swapped_faces"]))
 
-        placeholder = predicted["image"] / 255.0
-        placeholder = np.concatenate((placeholder,
-                                      np.zeros((frame_size[1], frame_size[0], 1))),
-                                     axis=-1).astype("float32")
+        placeholder = np.zeros((frame_size[1], frame_size[0], 4), dtype="float32")
+        background = predicted["image"] / np.array(255.0, dtype="float32")
+        placeholder[:, :, :3] = background
+
         for new_face, detected_face in zip(predicted["swapped_faces"],
                                            predicted["detected_faces"]):
             predicted_mask = new_face[:, :, -1] if new_face.shape[2] == 4 else None
@@ -140,7 +145,7 @@ class Converter():
             new_face = self.pre_warp_adjustments(src_face, new_face, detected_face, predicted_mask)
 
             # Warp face with the mask
-            placeholder = cv2.warpAffine(  # pylint: disable=no-member
+            cv2.warpAffine(  # pylint: disable=no-member
                 new_face,
                 detected_face.reference_matrix,
                 frame_size,
@@ -148,11 +153,11 @@ class Converter():
                 flags=cv2.WARP_INVERSE_MAP | interpolator,  # pylint: disable=no-member
                 borderMode=cv2.BORDER_TRANSPARENT)  # pylint: disable=no-member
 
-            placeholder = np.clip(placeholder, 0.0, 1.0)
+        np.clip(placeholder, 0.0, 1.0, out=placeholder)
         logger.trace("Got filename: '%s'. (placeholders: %s)",
                      predicted["filename"], placeholder.shape)
 
-        return placeholder
+        return placeholder, background
 
     def pre_warp_adjustments(self, old_face, new_face, detected_face, predicted_mask):
         """ Run the pre-warp adjustments """
@@ -178,11 +183,11 @@ class Converter():
         else:
             logger.trace("Adding mask to alpha channel")
             new_face = np.concatenate((new_face, mask), -1)
-        new_face = np.clip(new_face, 0.0, 1.0)
+        np.clip(new_face, 0.0, 1.0, out=new_face)
         logger.trace("Got mask. Image shape: %s", new_face.shape)
         return new_face, raw_mask
 
-    def post_warp_adjustments(self, predicted, new_image):
+    def post_warp_adjustments(self, background, new_image):
         """ Apply fixes to the image after warping """
         if self.adjustments["scaling"] is not None:
             new_image = self.adjustments["scaling"].run(new_image)
@@ -190,13 +195,11 @@ class Converter():
         if self.draw_transparent:
             frame = new_image
         else:
-            mask = np.repeat(new_image[:, :, -1][:, :, np.newaxis], 3, axis=-1)
-            foreground = new_image[:, :, :3]
-            background = (predicted["image"][:, :, :3] / 255.0) * (1.0 - mask)
-
+            foreground, mask = np.split(new_image, (3, ), axis=-1)
             foreground *= mask
-            frame = foreground + background
-
+            background *= (1.0 - mask)
+            background += foreground
+            frame = background
         np.clip(frame, 0.0, 1.0, out=frame)
         return frame
 
@@ -210,4 +213,5 @@ class Converter():
                 round((frame.shape[0] / 2 * self.scale) * 2))
         frame = cv2.resize(frame, dims, interpolation=interp)  # pylint: disable=no-member
         logger.trace("resized frame: %s", frame.shape)
-        return np.clip(frame, 0.0, 1.0)
+        np.clip(frame, 0.0, 1.0, out=frame)
+        return frame

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -648,8 +648,8 @@ class Predict():
             logger.trace("Putting to queue. ('%s', detected_faces: %s, swapped_faces: %s)",
                          item["filename"], len(item["detected_faces"]),
                          item["swapped_faces"].shape[0])
-            self.out_queue.put(item)
             pointer += num_faces
+        self.out_queue.put(batch)
         logger.trace("Queued out batch. Batchsize: %s", len(batch))
 
 


### PR DESCRIPTION
This PR optimized the conversion speed.
This is done mainly by choosing more performant variants for the numpy processing in the `Converter` class.

The Converter now also gets whole batches from the `Predict.queue_out_frames` method. This was mainly done to enable batch processing and potential replacing numpy functions with keras ones later on, but it also increased my speed by about 3it/s.

Optimizing the worker Plugins remains to be done. They did not take enough time in my setup to be really relevant. This may be different with other settings.

Benchmarks:
- Current staging: 16.45 it/s
- This PR WITHOUT providing whole batches to the converter: 21.40 it/s
- This PR as is: 24.69 it/s

Tested on 10k frames with a resolution of 1280x720.
The tested model on my system can do raw prediction (without anything else) with about 37.2 it/s
