### PR TITLE
Fixed convert bug in preview

### DIFF
--- a/lib/convert.py
+++ b/lib/convert.py
@@ -86,6 +86,8 @@ class Converter():
                 in_queue.put(items)
                 break
 
+            if isinstance(items, dict):
+                items = [items]
             for item in items:
                 logger.trace("Patch queue got: '%s'", item["filename"])
                 try:

--- a/tools/preview.py
+++ b/tools/preview.py
@@ -245,13 +245,14 @@ class Samples():
             idx = 0
             while idx < self.sample_size:
                 logger.debug("Predicting face %s of %s", idx + 1, self.sample_size)
-                item = self.predictor.out_queue.get()
-                if item == "EOF":
+                items = self.predictor.out_queue.get()
+                if items == "EOF":
                     logger.debug("Received EOF")
                     break
-                self.predicted_images.append(item)
-                logger.debug("Predicted face %s of %s", idx + 1, self.sample_size)
-                idx += 1
+                for item in items:
+                    self.predicted_images.append(item)
+                    logger.debug("Predicted face %s of %s", idx + 1, self.sample_size)
+                    idx += 1
         logger.debug("Predicted faces")
 
 


### PR DESCRIPTION
The tools->preview feature broke due to my recent convert speedup PR which provided whole batches to the convert.Converter.
This PR fixes that problem.

There seem to be a GUI bug tho, which i failed to fix properly.

```
Traceback (most recent call last):
File "/home/nope/workspace/fswap/faceswap/lib/cli.py", line 125, in execute_script
process.process()
File "/home/nope/workspace/fswap/faceswap/tools/preview.py", line 102, in process
self.build_ui()
File "/home/nope/workspace/fswap/faceswap/tools/preview.py", line 133, in build_ui
self.opts_book = OptionsBook(options_frame, self.config_tools, self.refresh, self.scaling)
File "/home/nope/workspace/fswap/faceswap/tools/preview.py", line 825, in __init__
self.build_sub_tabs()
File "/home/nope/workspace/fswap/faceswap/tools/preview.py", line 845, in build_sub_tabs
config_dict)
File "/home/nope/workspace/fswap/faceswap/tools/preview.py", line 882, in __init__
self.build_frame(parent, config_key)
File "/home/nope/workspace/fswap/faceswap/tools/preview.py", line 906, in build_frame
radio_columns=4)
File "/home/nope/workspace/fswap/faceswap/lib/gui/control_helper.py", line 307, in __init__
control_width)
File "/home/nope/workspace/fswap/faceswap/lib/gui/control_helper.py", line 383, in build_control
control_width)
File "/home/nope/workspace/fswap/faceswap/lib/gui/control_helper.py", line 409, in build_one_control
ctl = self.control_to_checkframe()
File "/home/nope/workspace/fswap/faceswap/lib/gui/control_helper.py", line 497, in control_to_checkframe
chkframe = self.chkbtns.subframe
AttributeError: 'NoneType' object has no attribute 'subframe'
08/27/2019 11:34:09 CRITICAL An unexpected crash has occurred.
```

@torzdf It is probably way faster if you give that one a try as you are the one with experience regarding the GUI ;)
You should be able to push to my `fix_preview` branch.