### PR TITLE
Added simple travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 !plugins/convert/*
 !tools
 !tools/lib*
+!.travis.yml
 *.ini
 *.pyc
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,91 @@
+# Adapted from https://github.com/kangwonlee/travis-yml-conda-posix-nt/blob/master/.travis.yml
+
+language: shell
+
+env:
+  global:
+    - CONDA_PYTHON=3.6
+    - CONDA_BLD_PATH=${HOME}/conda-bld
+
+os:
+  - linux
+  # - windows
+  # - osx
+
+
+cache:
+  # More time is needed for caching due to the sheer size of the conda env.
+  timeout: 1000
+  directories:
+    - ${HOME}/cache
+
+before_cache:
+  # adapted from https://github.com/theochem/cgrid/blob/master/.travis.yml
+  - rm -rf ${MINICONDA_PATH}/conda-bld
+  - rm -rf ${MINICONDA_PATH}/locks
+  - rm -rf ${MINICONDA_PATH}/pkgs
+  - rm -rf ${MINICONDA_PATH}/var
+  - rm -rf ${MINICONDA_PATH}/envs/*/conda-bld
+  - rm -rf ${MINICONDA_PATH}/envs/*/locks
+  - rm -rf ${MINICONDA_PATH}/envs/*/pkgs
+  - rm -rf ${MINICONDA_PATH}/envs/*/var
+  # Clean out test results
+  - rm -rf ${HOME}/cache/tests/*/faces
+  - rm -rf ${HOME}/cache/tests/*/conv
+  - rm -rf ${HOME}/cache/tests/*/*.json
+  - rm -rf ${HOME}/cache/tests/vid/faces_sorted
+  - rm -rf ${HOME}/cache/tests/vid/model
+
+before_install:
+  # set conda path info
+  - |
+    if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
+      MINICONDA_PATH=${HOME}/cache/miniconda;
+      MINICONDA_SUB_PATH=$MINICONDA_PATH/bin;
+    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      MINICONDA_PATH=${HOME}/cache/miniconda3/;
+      MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`;
+      MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts;
+    fi;
+  # obtain miniconda installer
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    # Not used at the moment, but in case we want to also run test on osx, we can.
+    elif  [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+    fi;
+
+install:
+  # install miniconda
+  # pip and conda will also need OpenSSL for Windows
+  - |
+    if test -e "$MINICONDA_PATH"; then
+      echo "Conda already installed";
+    else
+      echo "Installing conda";
+      if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
+        bash miniconda.sh -b -p $MINICONDA_PATH;
+      elif  [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+        choco install openssl.light;
+        choco install miniconda3 --params="'/AddToPath:1 /D:$MINICONDA_PATH_WIN'";
+      fi;
+    fi;
+  - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$PATH";
+  # for conda version 4.4 or later
+  - source $MINICONDA_PATH/etc/profile.d/conda.sh;
+  - hash -r;
+  - conda config --set always_yes yes --set changeps1 no;
+  - conda update -q conda;
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - echo "Python $CONDA_PYTHON running on $TRAVIS_OS_NAME";
+  # Only create the environment if we don't have it already
+  - conda env list | grep faceswap || conda create -q --name faceswap python=$CONDA_PYTHON;
+  - conda activate faceswap;
+  - conda --version ; python --version ; pip --version;
+  - python setup.py --installer;
+
+script:
+  - python simple_tests.py;
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 <br />Jennifer Lawrence/Steve Buscemi FaceSwap using the Villain model
 </p>
 
+[![Build Status](https://travis-ci.org/deepfakes/faceswap.svg?branch=master)](https://travis-ci.org/deepfakes/faceswap)
+
 Make sure you check out [INSTALL.md](INSTALL.md) before getting started.
 
 - [deepfakes_faceswap](#deepfakesfaceswap)

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -114,15 +114,17 @@ class ScriptExecutor():
         is_gui = hasattr(arguments, "redirect_gui") and arguments.redirect_gui
         log_setup(arguments.loglevel, arguments.logfile, self.command, is_gui)
         logger.debug("Executing: %s. PID: %s", self.command, os.getpid())
+        success = False
         if get_backend() == "amd":
             plaidml_found = self.setup_amd(arguments.loglevel)
             if not plaidml_found:
-                safe_shutdown()
-                exit(1)
+                safe_shutdown(got_error=True)
+                return
         try:
             script = self.import_script()
             process = script(arguments)
             process.process()
+            success = True
         except FaceswapError as err:
             for line in str(err).splitlines():
                 logger.error(line)
@@ -141,7 +143,7 @@ class ScriptExecutor():
                             "before reporting", crash_file)
 
         finally:
-            safe_shutdown()
+            safe_shutdown(got_error=not success)
 
     @staticmethod
     def setup_amd(loglevel):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -445,7 +445,7 @@ def camel_case_split(identifier):
     return [m.group(0) for m in matches]
 
 
-def safe_shutdown():
+def safe_shutdown(got_error=False):
     """ Close queues, threads and processes in event of crash """
     logger = logging.getLogger(__name__)  # pylint:disable=invalid-name
     logger.debug("Safely shutting down")
@@ -458,6 +458,7 @@ def safe_shutdown():
     while not queue_manager._log_queue.empty():  # pylint:disable=protected-access
         continue
     queue_manager.manager.shutdown()
+    exit(1 if got_error else 0)
 
 
 class FaceswapError(Exception):

--- a/simple_tests.py
+++ b/simple_tests.py
@@ -1,0 +1,190 @@
+"""
+Contains some simple tests.
+The purpose of this tests is to detect crashes and hangs
+but NOT to guarantee the corectness of the operations.
+For this we want another set of testcases using pytest.
+
+Due to my lazy coding, DON'T USE PATHES WITH BLANKS !
+"""
+
+import sys
+from subprocess import check_call, CalledProcessError
+import urllib
+from urllib.request import urlretrieve
+import os
+from os.path import join as pathjoin, expanduser
+
+fail_count = 0
+test_count = 0
+_COLORS = {
+    "FAIL": "\033[1;31m",
+    "OK": "\033[1;32m",
+    "STATUS": "\033[1;37m",
+    "BOLD": "\033[1m",
+    "ENDC": "\033[0m"
+}
+
+
+def print_colored(text, color="OK", bold=False):
+    # This might not work on windows,
+    # altho travis runs windows stuff in git bash, so it might ?
+    color = _COLORS.get(color, color)
+    print("%s%s%s%s" % (
+        color, "" if not bold else _COLORS["BOLD"], text, _COLORS["ENDC"]
+    ))
+
+
+def print_ok(text):
+    print_colored(text, "OK", True)
+
+
+def print_fail(text):
+    print_colored(text, "FAIL", True)
+
+
+def print_status(text):
+    print_colored(text, "STATUS", True)
+
+
+def run_test(name, cmd):
+    global fail_count, test_count
+    print_status("[?] running %s" % name)
+    print("Cmd: %s" % " ".join(cmd))
+    test_count += 1
+    try:
+        check_call(cmd)
+        print_ok("[+] Test success")
+        return True
+    except CalledProcessError as e:
+        print_fail("[-] Test failed with %s" % e)
+        fail_count += 1
+        return False
+
+
+def download_file(url, filename):  # TODO: retry
+    if os.path.isfile(filename):
+        print_status("[?] '%s' already cached as '%s'" % (url, filename))
+        return filename
+    try:
+        print_status("[?] Downloading '%s' to '%s'" % (url, filename))
+        video, _ = urlretrieve(url, filename)
+        return video
+    except urllib.error.URLError as e:
+        print_fail("[-] Failed downloading: %s" % e)
+        return None
+
+
+def extract_args(detector, aligner, in_path, out_path, args=None):
+    py_exe = sys.executable
+    _extract_args = "%s faceswap.py extract -i %s -o %s -D %s -A %s" % (
+        py_exe, in_path, out_path, detector, aligner
+    )
+    if args:
+        _extract_args += " %s" % args
+    return _extract_args.split()
+
+
+def train_args(model, model_path, faces, alignments, iterations=5, bs=8):
+    py_exe = sys.executable
+    args = "%s faceswap.py train -A %s -ala %s -B %s -alb %s -m %s -t %s -bs %i -it %s" % (
+        py_exe, faces, alignments, faces, alignments, model_path, model, bs, iterations
+    )
+    return args.split()
+
+
+def convert_args(in_path, out_path, model_path, writer, args=None):
+    py_exe = sys.executable
+    conv_args = "%s faceswap.py convert -i %s -o %s -m %s -w %s" % (
+        py_exe, in_path, out_path, model_path, writer
+    )
+    if args:
+        conv_args += " %s" % args
+    return conv_args.split()  # Don't use pathes with spaces ;)
+
+
+def sort_args(in_path, out_path, sortby="face", groupby="hist", method="rename"):
+    py_exe = sys.executable
+    _sort_args = "%s tools.py sort -i %s -o %s -s %s -fp %s -g %s -k" % (
+        py_exe, in_path, out_path, sortby, method, groupby
+    )
+    return _sort_args.split()
+
+
+if __name__ == '__main__':
+    vid_src = "https://faceswap.dev/data/test.mp4"
+    img_src = "https://archive.org/download/GPN-2003-00070/GPN-2003-00070.jpg"
+    base_dir = pathjoin(expanduser("~"), "cache", "tests")
+
+    vid_base = pathjoin(base_dir, "vid")
+    img_base = pathjoin(base_dir, "imgs")
+    os.makedirs(vid_base, exist_ok=True)
+    os.makedirs(img_base, exist_ok=True)
+    py_exe = sys.executable
+
+    vid_path = download_file(vid_src, pathjoin(vid_base, "test.mp4"))
+    if not vid_path:
+        print_fail("[-] Aborting")
+        exit(1)
+    vid_extract = run_test(
+        "Extraction video with cv2-dnn detector and cv2-dnn aligner.",
+        extract_args("Cv2-Dnn", "Cv2-Dnn", vid_path, pathjoin(vid_base, "faces"))
+    )
+
+    img_path = download_file(img_src, pathjoin(img_base, "test_img.jpg"))
+    if not img_path:
+        print_fail("[-] Aborting")
+        exit(1)
+    img_extract = run_test(
+        "Extraction images with cv2-dnn detector and cv2-dnn aligner.",
+        extract_args("Cv2-Dnn", "Cv2-Dnn", img_base, pathjoin(img_base, "faces"))
+    )
+
+    if vid_extract:
+        run_test(
+            "Sort faces.",
+            sort_args(
+                pathjoin(vid_base, "faces"), pathjoin(vid_base, "faces_sorted"),
+                sortby="face", method="rename"
+            )
+        )
+
+        run_test(
+            "Rename sorted faces.",
+            (
+                py_exe, "tools.py", "alignments", "-j", "rename",
+                "-a", pathjoin(vid_base, "test_alignments.json"),
+                "-fc", pathjoin(vid_base, "faces_sorted"),
+            )
+        )
+
+        trained = run_test(
+            "Train lightweight model for 5 iterations.",
+            train_args(
+                "lightweight", pathjoin(vid_base, "model"),
+                pathjoin(vid_base, "faces"), pathjoin(vid_base, "test_alignments.json")
+            )
+        )
+
+    if trained:
+        run_test(
+            "Convert video.",
+            convert_args(
+                vid_path, pathjoin(vid_base, "conv"),
+                pathjoin(vid_base, "model"), "ffmpeg"
+            )
+        )
+
+        run_test(
+            "Convert images.",
+            convert_args(
+                img_base, pathjoin(img_base, "conv"),
+                pathjoin(vid_base, "model"), "opencv"
+            )
+        )
+
+    if fail_count == 0:
+        print_ok("[+] Failed %i/%i tests." % (fail_count, test_count))
+        exit(0)
+    else:
+        print_fail("[-] Failed %i/%i tests." % (fail_count, test_count))
+        exit(1)


### PR DESCRIPTION
This adds simple test cases using travis.
It does this by running different faceswap job with sub processes.
Namely:
- Extract from short video
- Extract from image
- Sort
- Rename
- Train 5 iterations with lightweight
- Convert images
- Convert video

These tests are only to detect crashes and hangs.
To test for correct results we might want to add some tests using pytest at some later time.

I don't have permissions to enable travis tests for this repo. Please activate it at:
https://travis-ci.org/deepfakes/faceswap

It shouldn't matter if the tests on travis are activated for all branches as it will only run when the .travis file exists.

For an example run see: https://travis-ci.org/kilroythethird/faceswap