### PR TITLE
Optimized mtcnn a bit + added batching

### DIFF
--- a/plugins/extract/_base.py
+++ b/plugins/extract/_base.py
@@ -322,7 +322,7 @@ class Extractor():
                      self.__class__.__name__, args, kwargs)
         p_type = "Detector" if self._plugin_type == "detect" else "Aligner"
         logger.info("Initializing %s %s...", self.name, p_type)
-        self.queue_size = kwargs["queue_size"]
+        self.queue_size = 1
         self._add_queues(kwargs["in_queue"], kwargs["out_queue"], ["predict", "post"])
         self._compile_threads()
         self.init_model()

--- a/plugins/extract/detect/mtcnn_defaults.py
+++ b/plugins/extract/detect/mtcnn_defaults.py
@@ -106,4 +106,17 @@ _DEFAULTS = {
         "gui_radio": False,
         "fixed": True,
     },
+    "batch-size": {
+        "default": 8,
+        "info": "The batch size to use. To a point, higher batch sizes equal better performance, "
+                "but setting it too high can harm performance.\n"
+                "\n\tNvidia users: If the batchsize is set higher than the your GPU can "
+                "accomodate then this will automatically be lowered.",
+        "datatype": int,
+        "rounding": 1,
+        "min_max": (1, 64),
+        "choices": [],
+        "gui_radio": False,
+        "fixed": True,
+    }
 }

--- a/plugins/extract/pipeline.py
+++ b/plugins/extract/pipeline.py
@@ -323,8 +323,7 @@ class Extractor():
         """ Launch the face aligner """
         logger.debug("Launching Aligner")
         kwargs = dict(in_queue=self._queues["extract_align_in"],
-                      out_queue=self._queues["extract_align_out"],
-                      queue_size=self._queue_size)
+                      out_queue=self._queues["extract_align_out"])
         self._aligner.initialize(**kwargs)
         self._aligner.start()
         logger.debug("Launched Aligner")
@@ -333,8 +332,7 @@ class Extractor():
         """ Launch the face detector """
         logger.debug("Launching Detector")
         kwargs = dict(in_queue=self._queues["extract_detect_in"],
-                      out_queue=self._queues["extract_align_in"],
-                      queue_size=self._queue_size)
+                      out_queue=self._queues["extract_align_in"])
         self._detector.initialize(**kwargs)
         self._detector.start()
         logger.debug("Launched Detector")


### PR DESCRIPTION
- Reduced image size for mtcnn from `1440**2` to `640**2`. This increases speed dramatically and didn't have any negative impact in my tests.
- Added batching to mtcnn.
- Set queue_size for all intermediate queues to 1. Ie: if the next step in the pipeline is blocking 2 full batches will be waiting (1 in queue, 1 waiting to be added to the queue). I didn't saw any speed difference between size 1 and higher sizes.
- Added optimized prediction for amd backends which tries to minimize the kernels to be compiled while keeping the BS as high as possible. Only active when `batch_size` parameter is provided in the predict call.

Batching in mtcnn is only done partial (altho for the most relevant part). There is still room for performance optimization.
`mtcnn.vram_per_batch` still needs to be set to the appropiate value (no nvidia card here to test)

Example speed difference with tf-CPU:
- 01:07 minutes for 300 images with current staging
- 00:19 minutes for 300 images with this PR

Changes with the AMD backend are also noticeable, altho not as big due to the kernel compile time.