### PR TITLE
Plaidml error message when no device is found

### DIFF
--- a/lib/plaidml_tools.py
+++ b/lib/plaidml_tools.py
@@ -184,6 +184,10 @@ class PlaidMLStats():
         if _LOGGER:
             _LOGGER.debug("Obtaining largest %s device", category)
         indices = getattr(self, "{}_indices".format(category))
+        if not indices:
+            _LOGGER.error("Failed to automatically detect your GPU.")
+            _LOGGER.error("Please run `plaidml-setup` to set up your GPU.")
+            exit()
         max_vram = max([self.vram[idx] for idx in indices])
         if _LOGGER:
             _LOGGER.debug("Max VRAM: %s", max_vram)


### PR DESCRIPTION
Suggest a possible solution when plaidml_tools can't find the GPU with the largest VRAM amount.
Especially interesting for non openCL backends.

I am open for a better log text.