### PR TITLE
Batchsize type mismatch

### DIFF
--- a/plugins/extract/pipeline.py
+++ b/plugins/extract/pipeline.py
@@ -460,7 +460,7 @@ class Extractor():
     @staticmethod
     def _set_plugin_batchsize(plugin, available_vram):
         """ Set the batch size for the given plugin based on given available vram """
-        plugin.batchsize = max(1, available_vram // plugin.vram_per_batch)
+        plugin.batchsize = int(max(1, available_vram // plugin.vram_per_batch))
         logger.verbose("Reset batchsize for %s to %s", plugin.name, plugin.batchsize)
 
     def _join_threads(self):


### PR DESCRIPTION
Extraction is broken for me in staging branch, I propose a small fix
Log output before:
```
Loading...
Setting Faceswap backend to NVIDIA
10/26/2019 20:04:36 INFO     Log level set to: TRACE
10/26/2019 20:04:37 INFO     Output Directory: /data/test/009_extracted
10/26/2019 20:04:37 INFO     Input Video: /data/test/009.mkv
10/26/2019 20:04:37 VERBOSE  Alignments filepath: '/data/test/009_alignments.fsa'
10/26/2019 20:04:37 INFO     Loading Detect from S3Fd plugin...
10/26/2019 20:04:37 VERBOSE  Loading config: '/srv/config/extract.ini'
10/26/2019 20:04:37 INFO     Loading Align from Fan plugin...
10/26/2019 20:04:37 VERBOSE  Loading config: '/srv/config/extract.ini'
10/26/2019 20:04:37 INFO     Loading Mask from Vgg_Clear plugin...
10/26/2019 20:04:37 VERBOSE  Loading config: '/srv/config/extract.ini'
10/26/2019 20:04:37 VERBOSE  GeForce RTX 2080 Ti - 11018MB free of 11019MB
10/26/2019 20:04:37 VERBOSE  Reset batchsize for S3FD to 9.0
10/26/2019 20:04:37 VERBOSE  Reset batchsize for FAN to 29.0
10/26/2019 20:04:37 VERBOSE  Reset batchsize for VGG Clear to 4.0
10/26/2019 20:04:37 INFO     Starting, this may take a while...
10/26/2019 20:04:37 INFO     Initializing S3FD (Detect)...
10/26/2019 20:04:37 WARNING  From /srv/lib/model/session.py:112: The name tf.ConfigProto is deprecated. Please use tf.compat.v1.ConfigProto instead.\n
10/26/2019 20:04:37 WARNING  From /srv/lib/model/session.py:116: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.\n
10/26/2019 20:04:38 VERBOSE  Initializing plugin model: S3FD
10/26/2019 20:04:38 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:517: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.\n
10/26/2019 20:04:38 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:245: The name tf.get_default_graph is deprecated. Please use tf.compat.v1.get_default_graph instead.\n
10/26/2019 20:04:38 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:174: The name tf.get_default_session is deprecated. Please use tf.compat.v1.get_default_session instead.\n
10/26/2019 20:04:38 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:3976: The name tf.nn.max_pool is deprecated. Please use tf.nn.max_pool2d instead.\n
10/26/2019 20:04:39 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/optimizers.py:790: The name tf.train.Optimizer is deprecated. Please use tf.compat.v1.train.Optimizer instead.\n
10/26/2019 20:04:39 INFO     Initialized S3FD (Detect) with batchsize of 9.0

10/26/2019 20:04:39 INFO     Initializing FAN (Align)...
10/26/2019 20:04:39 VERBOSE  Initializing plugin model: FAN
10/26/2019 20:04:39 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:3980: The name tf.nn.avg_pool is deprecated. Please use tf.nn.avg_pool2d instead.\n
10/26/2019 20:04:40 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:2018: The name tf.image.resize_nearest_neighbor is deprecated. Please use tf.compat.v1.image.resize_nearest_neighbor instead.\n
Process exited.
```

Error traceback looks like this:
```
['Traceback (most recent call last):\n',
'  File "/srv/lib/multithreading.py", line 37, in run\n'
'    self._target(*self._args, **self._kwargs)\n',
'  File "/srv/plugins/extract/_base.py", line 393, in _thread_process\n'
'    exhausted, batch = self.get_batch(in_queue)\n',
'  File "/srv/plugins/extract/detect/_base.py", line 108, in get_batch\n'
'    for _ in range(self.batchsize):\n',
"TypeError: 'float' object cannot be interpreted as an integer\n"]
```
Log output after patching:
```
Loading...
Setting Faceswap backend to NVIDIA
10/26/2019 20:17:17 INFO     Log level set to: TRACE
10/26/2019 20:17:18 INFO     Output Directory: /data/test/009_extracted
10/26/2019 20:17:18 INFO     Input Video: /data/test/009.mkv
10/26/2019 20:17:18 VERBOSE  Alignments filepath: '/data/test/009_alignments.fsa'
10/26/2019 20:17:18 INFO     Adding post processing item: Blurry Face Filter
10/26/2019 20:17:18 INFO     Loading Detect from S3Fd plugin...
10/26/2019 20:17:18 VERBOSE  Loading config: '/srv/config/extract.ini'
10/26/2019 20:17:18 INFO     Loading Align from Fan plugin...
10/26/2019 20:17:18 VERBOSE  Loading config: '/srv/config/extract.ini'
10/26/2019 20:17:18 INFO     Loading Mask from Vgg_Clear plugin...
10/26/2019 20:17:18 VERBOSE  Loading config: '/srv/config/extract.ini'
10/26/2019 20:17:18 VERBOSE  GeForce RTX 2080 Ti - 11018MB free of 11019MB
10/26/2019 20:17:18 VERBOSE  Reset batchsize for S3FD to 9
10/26/2019 20:17:18 VERBOSE  Reset batchsize for FAN to 29
10/26/2019 20:17:18 VERBOSE  Reset batchsize for VGG Clear to 4
10/26/2019 20:17:18 INFO     Starting, this may take a while...
10/26/2019 20:17:18 INFO     Initializing S3FD (Detect)...
10/26/2019 20:17:18 WARNING  From /srv/lib/model/session.py:112: The name tf.ConfigProto is deprecated. Please use tf.compat.v1.ConfigProto instead.\n
10/26/2019 20:17:18 WARNING  From /srv/lib/model/session.py:116: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.\n
10/26/2019 20:17:19 VERBOSE  Initializing plugin model: S3FD
10/26/2019 20:17:19 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:517: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.\n
10/26/2019 20:17:19 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:245: The name tf.get_default_graph is deprecated. Please use tf.compat.v1.get_default_graph instead.\n
10/26/2019 20:17:19 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:174: The name tf.get_default_session is deprecated. Please use tf.compat.v1.get_default_session instead.\n
10/26/2019 20:17:19 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:3976: The name tf.nn.max_pool is deprecated. Please use tf.nn.max_pool2d instead.\n
10/26/2019 20:17:19 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/optimizers.py:790: The name tf.train.Optimizer is deprecated. Please use tf.compat.v1.train.Optimizer instead.\n
10/26/2019 20:17:19 INFO     Initialized S3FD (Detect) with batchsize of 9
10/26/2019 20:17:19 INFO     Initializing FAN (Align)...
10/26/2019 20:17:19 VERBOSE  Initializing plugin model: FAN
10/26/2019 20:17:20 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:3980: The name tf.nn.avg_pool is deprecated. Please use tf.nn.avg_pool2d instead.\n
10/26/2019 20:17:20 WARNING  From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:2018: The name tf.image.resize_nearest_neighbor is deprecated. Please use tf.compat.v1.image.resize_nearest_neighbor instead.\n```