### PR TITLE
Fsa legacy alignment conversion fixes

### DIFF
--- a/lib/alignments.py
+++ b/lib/alignments.py
@@ -73,7 +73,7 @@ class Alignments():
     def get_location(self, folder, filename):
         """ Return the path to alignments file """
         logger.debug("Getting location: (folder: '%s', filename: '%s')", folder, filename)
-        extension = os.path.splitext(filename)[1]
+        noext_name, extension = os.path.splitext(filename)
         if extension in (".json", ".p", ".pickle", ".yaml", ".yml"):
             # Reformat legacy alignments file
             filename = self.update_file_format(folder, filename)
@@ -81,7 +81,7 @@ class Alignments():
         if extension[1:] == self.serializer.file_extension:
             logger.debug("Valid Alignments filename provided: '%s'", filename)
         else:
-            filename = "{}.{}".format(os.path.splitext(filename)[0], self.serializer.file_extension)
+            filename = "{}.{}".format(noext_name, self.serializer.file_extension)
             logger.debug("File extension set from serializer: '%s'",
                          self.serializer.file_extension)
         location = os.path.join(str(folder), filename)

--- a/lib/gui/utils.py
+++ b/lib/gui/utils.py
@@ -92,7 +92,7 @@ class FileHandler():
         """ Set the filetypes for opening/saving """
         all_files = ("All files", "*.*")
         filetypes = {"default": (all_files,),
-                     "alignments": [("Faceswap Alignments", "*.fsa"),
+                     "alignments": [("Faceswap Alignments", "*.fsa *.json"),
                                     all_files],
                      "config": [("Faceswap GUI config files", "*.fsw"), all_files],
                      "csv": [("Comma separated values", "*.csv"), all_files],


### PR DESCRIPTION
Fixes the double .fsa bug referenced in #919 #921 and also fixed in #922
Also adds *.json to the filter from the open alignments dialog in the GUI to make it easier to work with old data.