### PR TITLE
Added masking output support to tools->mask

### DIFF
--- a/tools/cli.py
+++ b/tools/cli.py
@@ -547,6 +547,24 @@ class MaskArgs(FaceSwapArgs):
             "help": "Helps reduce 'blotchiness' on some masks by making light shades white "
                     "and dark shades black. Higher values will impact more of the mask. NB: "
                     "Only effects the output preview. Set to 0 for off"})
+        argument_list.append({
+            "opts": ("-ot", "--output-type"),
+            "action": Radio,
+            "type": str.lower,
+            "choices": ("combined", "masked", "mask"),
+            "default": "combined",
+            "group": "output",
+            "help": "R|How to format the output when processing is set to 'output'."
+                    "\nL|combined: The image contains the face/frame, face mask and masked face."
+                    "\nL|masked: Output the face/frame as rgba image with the face masked."
+                    "\nL|mask: Only output the mask as a single channel image."})
+        argument_list.append({
+            "opts": ("-f", "--full-frame"),
+            "action": "store_true",
+            "default": False,
+            "group": "output",
+            "help": "R|Whether to output the whole frame or only the face box when using "
+                    "output processing. Only has an effect when using frames as input."})
 
         return argument_list
 


### PR DESCRIPTION
Currently the mask tool outputs a combination of face, mask and masked face.
This PR add options to output only the mask or the masked face too.
Additionally it adds an option to output the whole frame.

This allows using the extraction and masking part of faceswap in an after effects workflow.
I am aware that this is not the goal of faceswap but since it became a pretty nice face extraction / clean and masking tool it would be nice to have.
This will become even more interesting as soon as better obstruction mask models are implemented.