### PR TITLE
add sys.exit

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+from sys import exit
 import urllib
 import warnings
 import zipfile


### PR DESCRIPTION
In python 3.6.9, I get an error: `NameError: name 'exit' is not defined`. This PR fixes this
