### PR TITLE
Speedup mask loading before training start

### DIFF
--- a/plugins/train/trainer/_base.py
+++ b/plugins/train/trainer/_base.py
@@ -1290,8 +1290,9 @@ class TrainingAlignments():
         """
 
         masks = dict()
-        #for face in tqdm(detected_faces, desc="Loading masks in side %s" % side.title()):
-        for face in tqdm(detected_faces, desc="Loading masks"):
+        for face in tqdm(detected_faces,
+                         desc="Loading masks in side %s" % side.title(),
+                         mininterval=1):
             mask = face.mask[self._training_opts["mask_type"]]
             mask.set_blur_kernel_and_threshold(blur_kernel=self._training_opts["mask_blur_kernel"],
                                                threshold=self._training_opts["mask_threshold"])


### PR DESCRIPTION
Roughly 10x speedup of loading masks into the training dictionary prior to training start.

For large data-sets, this setup time can be large. For a test set of 85k images, the mask loading time was 5 minutes, 40 seconds long on my computer . This PR reduces the mask loading time to 40 secs.