### PR TITLE
Fix Bug if input size is different than 128

### DIFF
--- a/plugins/train/model/villain.py
+++ b/plugins/train/model/villain.py
@@ -38,7 +38,7 @@ class Model(OriginalModel):
         tmp_x = var_x
         res_cycles = 8 if self.config.get("lowmem", False) else 16
         for _ in range(res_cycles):
-            nn_x = self.blocks.res_block(var_x, 128, **kwargs)
+            nn_x = self.blocks.res_block(var_x, in_conv_filters, **kwargs)
             var_x = nn_x
         # consider adding scale before this layer to scale the residual chain
         var_x = add([var_x, tmp_x])


### PR DESCRIPTION
At the moment if the input size is different than 128 the model structure building fails on this line: `var_x = add([var_x, tmp_x])`https://github.com/deepfakes/faceswap/blob/master/plugins/train/model/villain.py#L41

This is because the number of filters in `var_x` and `tmp_x` are different. On line 37 and 38, `tmp_x` is created using  # of filters `in_conv_filters` but  `var_x` using 128, then when we try to add them, there is dimension mismatch on the 3rd dimension (# of filters).