### PR TITLE
Matplotlib fails, revert to 3.0.3?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Pillow==6.2.1
 scikit-learn
 toposort
 fastcluster
-matplotlib==3.1.1
+matplotlib==3.0.3
 imageio==2.6.1
 imageio-ffmpeg
 ffmpy==0.2.2


### PR DESCRIPTION
Hey, 
Matplotlib fails in docker, ubuntu 16, 18 ,19.
Is it okay to revert to 3.0.3 which works with pip install? In my setup it seems to work.