### PR TITLE
Update Tensorflow Docker image

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,6 @@
-FROM tensorflow/tensorflow:1.12.0-gpu-py3
+FROM tensorflow/tensorflow:1.15.0-gpu-py3
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 \
  && apt-get update -qq -y \
@@ -12,11 +14,6 @@ RUN pip3 --no-cache-dir install -r /opt/requirements.txt && rm /opt/requirements
 RUN pip3 install jupyter matplotlib
 RUN pip3 install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
-# patch for tensorflow:latest-gpu-py3 image
-RUN cd /usr/local/cuda/lib64 \
- && mv stubs/libcuda.so ./ \
- && ln -s libcuda.so libcuda.so.1 \
- && ldconfig
 
 WORKDIR "/notebooks"
 CMD ["jupyter-notebook", "--allow-root" ,"--port=8888" ,"--no-browser" ,"--ip=0.0.0.0"]

--- a/docs/sphinx_requirements.txt
+++ b/docs/sphinx_requirements.txt
@@ -22,4 +22,4 @@ h5py==2.9.0
 Keras==2.2.4
 pywin32 ; sys_platform == "win32"
 pynvx==0.0.4 ; sys_platform == "darwin"
-tensorflow
+tensorflow==1.15


### PR DESCRIPTION
It is not possible to build project against TF 1.12 container, as it is based on old version of Python.
Also, solves #970