### PR TITLE
Change temporal-spatio smoothing to spatial smoothing

### DIFF
--- a/tools/alignments/jobs.py
+++ b/tools/alignments/jobs.py
@@ -1132,7 +1132,7 @@ class Spatial():
     def temporally_smooth(landmarks):
         """ apply temporal filtering on the 2D points """
         logger.debug("Temporally Smooth")
-        filter_half_length = 2
+        filter_half_length = 1
         temporal_filter = np.ones((1, 1, 2 * filter_half_length + 1))
         temporal_filter = temporal_filter / temporal_filter.sum()
 


### PR DESCRIPTION
Increase accuracy using 1 less frame for smoothing.  Subsequent runs can be done more smoothing rather than 1 shot garnering results closer to temporal if desired.