### PR TITLE
Added an option to skip outputting face images

### DIFF
--- a/lib/cli/args.py
+++ b/lib/cli/args.py
@@ -538,6 +538,13 @@ class ExtractArgs(ExtractConvertArgs):
             default=False,
             group="settings",
             help="Skip frames that already have detected faces in the alignments file"))
+        argument_list.append(dict(
+            opts=("-ssf", "--skip-saving-faces"),
+            action="store_true",
+            dest="skip_saving_faces",
+            default=False,
+            group="settings",
+            help="Skip saving out the face images"))
         return argument_list
 
 

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -213,7 +213,8 @@ class Extract():  # pylint:disable=too-few-public-methods
                 self._check_thread_error()
                 if is_final:
                     self._output_processing(extract_media, size)
-                    self._output_faces(saver, extract_media)
+                    if not self._args.skip_saving_faces:
+                        self._output_faces(saver, extract_media)
                     if self._save_interval and (idx + 1) % self._save_interval == 0:
                         self._alignments.save()
                 else:


### PR DESCRIPTION
Adds --skip-saving-faces -ssf to extract to skip saving out face images in extract.  (Semi quick hack)