### PR TITLE
Remove subpixel upscaling option

### DIFF
--- a/plugins/train/_config.py
+++ b/plugins/train/_config.py
@@ -136,13 +136,6 @@ class Config(FaceswapConfig):
                  "for this initialization technique are expensive. This will only impact starting "
                  "a new model.")
         self.add_item(
-            section=section, title="subpixel_upscaling", datatype=bool,
-            default=False, group="network",
-            info="Use subpixel upscaling rather than pixel shuffler. These techniques "
-                 "are both designed to produce better resolving upscaling than other "
-                 "methods. Each perform the same operations, but using different TF opts."
-                 "\n\t https://arxiv.org/pdf/1609.05158.pdf")
-        self.add_item(
             section=section, title="reflect_padding", datatype=bool,
             default=False, group="network",
             info="Use reflection padding rather than zero padding with convolutions. "

--- a/plugins/train/model/_base.py
+++ b/plugins/train/model/_base.py
@@ -83,8 +83,7 @@ class ModelBase():
                            self.vram_savings.pingpong,
                            training_image_size)
 
-        self.blocks = NNBlocks(use_subpixel=self.config["subpixel_upscaling"],
-                               use_icnr_init=self.config["icnr_init"],
+        self.blocks = NNBlocks(use_icnr_init=self.config["icnr_init"],
                                use_convaware_init=self.config["conv_aware_init"],
                                use_reflect_padding=self.config["reflect_padding"],
                                first_run=self.state.first_run)
@@ -377,9 +376,9 @@ class ModelBase():
         opt_kwargs = dict(lr=lr, beta_1=beta_1, beta_2=beta_2)
         if (self.config.get("clipnorm", False) and
                 keras.backend.backend() != "plaidml.keras.backend"):
-            # NB: Clipnorm is ballooning VRAM usage, which is not expected behavior
-            # and may be a bug in Keras/TF.
-            # PlaidML has a bug regarding the clipnorm parameter
+            # NB: Clip-norm is ballooning VRAM usage, which is not expected behavior
+            # and may be a bug in Keras/Tensorflow.
+            # PlaidML has a bug regarding the clip-norm parameter
             # See: https://github.com/plaidml/plaidml/issues/228
             # Workaround by simply removing it.
             # TODO: Remove this as soon it is fixed in PlaidML.
@@ -581,7 +580,6 @@ class ModelBase():
         self.state.inputs = {"face:0": [64, 64, 3]}
         self.state.training_size = 256
         self.state.config["coverage"] = 62.5
-        self.state.config["subpixel_upscaling"] = False
         self.state.config["reflect_padding"] = False
         self.state.config["mask_type"] = None
         self.state.config["mask_blur_kernel"] = 3
@@ -1014,7 +1012,7 @@ class State():
             set it to `mae`. Remove old `dssim_loss` item
 
             * masks - If `learn_mask` does not exist then it is set to ``True`` if `mask_type` is
-            not ``None`` otherwised it is set to ``False``.
+            not ``None`` otherwise it is set to ``False``.
 
             * masks type - Replace removed masks 'dfl_full' and 'facehull' with `components` mask
 

--- a/tests/lib/model/nn_blocks_test.py
+++ b/tests/lib/model/nn_blocks_test.py
@@ -15,14 +15,14 @@ from numpy.testing import assert_allclose
 from lib.model.nn_blocks import NNBlocks
 from lib.utils import get_backend
 
-_PARAMS = ["use_subpixel", "use_icnr_init", "use_convaware_init", "use_reflect_padding"]
+_PARAMS = ["use_icnr_init", "use_convaware_init", "use_reflect_padding"]
 _VALUES = list(product([True, False], repeat=len(_PARAMS)))
 _IDS = ["{}[{}]".format("|".join([_PARAMS[idx] for idx, b in enumerate(v) if b]),
                         get_backend().upper()) for v in _VALUES]
 
 
 def block_test(layer_func, kwargs={}, input_shape=None):
-    """Test routine for a faceswaps neural network blocks.
+    """Test routine for faceswap neural network blocks.
 
     Tests are simple and are to ensure that the blocks compile on both tensorflow
     and plaidml backends
@@ -62,13 +62,9 @@ def block_test(layer_func, kwargs={}, input_shape=None):
 
 
 @pytest.mark.parametrize(_PARAMS, _VALUES, ids=_IDS)
-def test_blocks(use_subpixel, use_icnr_init, use_convaware_init, use_reflect_padding):
+def test_blocks(use_icnr_init, use_convaware_init, use_reflect_padding):
     """ Test for all blocks contained within the NNBlocks Class """
-    if get_backend() == "amd" and use_subpixel:
-        # Subpixel upscaling does not work on plaidml so skip this test
-        pytest.skip("Subpixel upscaling not supported in plaidML")
-    cls_ = NNBlocks(use_subpixel=use_subpixel,
-                    use_icnr_init=use_icnr_init,
+    cls_ = NNBlocks(use_icnr_init=use_icnr_init,
                     use_convaware_init=use_convaware_init,
                     use_reflect_padding=use_reflect_padding)
     block_test(cls_.conv2d, input_shape=(2, 5, 5, 128), kwargs=dict(filters=1024, kernel_size=3))


### PR DESCRIPTION
This PR removes the subpixel upscaling option from training configuration.

The subpixel upscaling layer does exactly the same job as PixelShuffler, but uses Tensorflow specific ops, which means it will not work with AMD cards.

As the output is identical between the 2 layers, it makes sense to remove the backend limited version.

The layer is kept in the repo (although unselectable) so that previously saved models that used this layer can still be loaded.