### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
 !requirements*
+!_requirements*


### PR DESCRIPTION
I think `_requirements_base.txt` should not be included in `.Dockerignore`.
I could not build the docker image without this change.

I'm not that good at using Docker, so ignore this if it does not make sense.
