### PR TITLE
Add Mouth and Eye Priority to Loss options

### DIFF
--- a/lib/model/losses_tf.py
+++ b/lib/model/losses_tf.py
@@ -642,5 +642,4 @@ class LossWrapper(tf.keras.losses.Loss):
             if mask_channel != -1:
                 n_true = K.concatenate((n_true, y_true[..., mask_channel][..., None]))
             loss += func(n_true, y_pred) * weight
-        weighted_average = loss / sum(self._loss_weights)
-        return weighted_average
+        return loss

--- a/lib/model/losses_tf.py
+++ b/lib/model/losses_tf.py
@@ -568,31 +568,6 @@ class LossWrapper(tf.keras.losses.Loss):
         self._mask_channels = []
         logger.debug("Initialized: %s", self.__class__.__name__)
 
-    def _compile_losses(self, loss_functions):
-        """ Splits the given loss_functions into the corresponding :attr:`_loss_functions' and
-        :attr:`_loss_weights' lists.
-
-        Loss functions are compiled into :class:`keras.compile_utils.LossesContainer` objects
-
-        Parameters
-        ----------
-        loss_functions: list
-            A list of either a tuple of (:class:`keras.losses.Loss`, scalar weight) or just a
-            :class:`keras.losses.Loss` function. If just the loss function is passed, then the
-            weight is assumed to be 1.0 """
-        for loss_func in loss_functions:
-            if isinstance(loss_func, tuple):
-                assert len(loss_func) == 2, "Tuple loss functions should contain 2 items"
-                assert isinstance(loss_func[1], float), "weight should be a float"
-                func, weight = loss_func
-            else:
-                func = loss_func
-                weight = 1.0
-            self._loss_functions.append(compile_utils.LossesContainer(func))
-            self._loss_weights.append(weight)
-        logger.debug("Compiled losses: (functions: %s, weights: %s",
-                     self._loss_functions, self._loss_weights)
-
     def add_loss(self, function, weight=1.0, mask_channel=-1):
         """ Add the given loss function with the given weight to the loss function chain.
 

--- a/lib/model/losses_tf.py
+++ b/lib/model/losses_tf.py
@@ -641,5 +641,5 @@ class LossWrapper(tf.keras.losses.Loss):
             n_true = y_true[..., :3]
             if mask_channel != -1:
                 n_true = K.concatenate((n_true, y_true[..., mask_channel][..., None]))
-            loss += func(n_true, y_pred) * weight
+            loss += (func(n_true, y_pred) * weight)
         return loss

--- a/plugins/train/_config.py
+++ b/plugins/train/_config.py
@@ -266,6 +266,32 @@ class Config(FaceswapConfig):
                  "\n\t 0 - Disables L2 Regularization altogether.")
         self.add_item(
             section=section,
+            title="eye_multiplier",
+            datatype=int,
+            group="loss",
+            min_max=(1, 40),
+            rounding=1,
+            default=12,
+            info="The amount of priority to give to the eyes.\n\nThe value given here is as a "
+                 "multiplier of the main loss score. For example:"
+                 "\n\t 1 - The eyes will receive the same priority as the rest of the face. "
+                 "\n\t 10 - The eyes will be given a score 10 times higher than the rest of the "
+                 "face.")
+        self.add_item(
+            section=section,
+            title="mouth_multiplier",
+            datatype=int,
+            group="loss",
+            min_max=(1, 40),
+            rounding=1,
+            default=8,
+            info="The amount of priority to give to the mouth.\n\nThe value given here is as a "
+                 "multiplier of the main loss score. For example:"
+                 "\n\t 1 - The mouth will receive the same priority as the rest of the face. "
+                 "\n\t 10 - The mouth will be given a score 10 times higher than the rest of the "
+                 "face.")
+        self.add_item(
+            section=section,
             title="penalized_mask_loss",
             datatype=bool,
             default=True,

--- a/plugins/train/model/_base.py
+++ b/plugins/train/model/_base.py
@@ -992,33 +992,46 @@ class _Loss():
             The output names from the model
         """
         mask_channels = self._get_mask_channels()
+        face_loss = self._loss_dict[self._config["loss_function"]]
+
         for name, output_name in zip(self._names, output_names):
             if name.startswith("mask"):
                 loss_func = self._loss_dict[self._config["mask_loss_function"]]
             else:
                 loss_func = losses.LossWrapper()
-                loss_func.add_loss(self._loss_dict[self._config["loss_function"]],
-                                   mask_channel=mask_channels[0])
+                loss_func.add_loss(face_loss, mask_channel=mask_channels[0])
+                self._add_l2_regularization_term(loss_func, mask_channels[0])
 
-                if (self._config["loss_function"] in self._uses_l2_reg
-                        and self._config["l2_reg_term"] != 0):
-                    loss_func.add_loss(self._loss_dict["mse"],
-                                       weight=self._config["l2_reg_term"] / 100.0,
-                                       mask_channel=mask_channels[0])
-
-                if self._config["eye_multiplier"] > 1:
-                    loss_func.add_loss(self._loss_dict["mae"],
-                                       weight=self._config["eye_multiplier"] * 1.0,
-                                       mask_channel=mask_channels[1])
-
-                if self._config["mouth_multiplier"] > 1:
-                    loss_func.add_loss(self._loss_dict["mae"],
-                                       weight=self._config["mouth_multiplier"] * 1.0,
-                                       mask_channel=mask_channels[2])
+                mask_channel = 1
+                for multiplier in ("eye_multiplier", "mouth_multiplier"):
+                    if self._config[multiplier] > 1:
+                        loss_func.add_loss(face_loss,
+                                           weight=self._config[multiplier] * 1.0,
+                                           mask_channel=mask_channels[mask_channel])
+                        self._add_l2_regularization_term(loss_func, mask_channel)
+                    mask_channel += 1
 
             logger.debug("%s: (output_name: '%s', function: %s)", name, output_name, loss_func)
             self._funcs[output_name] = loss_func
         logger.debug("functions: %s", self._funcs)
+
+    def _add_l2_regularization_term(self, loss_wrapper, mask_channel):
+        """ Check if an L2 Regularization term should be added and add to the loss function
+        wrapper.
+
+        Parameters
+        ----------
+        loss_wrapper: :class:`lib.model.losses.LossWrapper`
+            The wrapper loss function that holds the face losses
+        mask_channel: int
+            The channel that holds the mask in `y_true`, if a mask is used for the loss.
+            `-1` if the input is not masked
+        """
+        if self._config["loss_function"] in self._uses_l2_reg and self._config["l2_reg_term"] > 0:
+            logger.debug("Adding L2 Regularization for Structural Loss")
+            loss_wrapper.add_loss(self._loss_dict["mse"],
+                                  weight=self._config["l2_reg_term"] / 100.0,
+                                  mask_channel=mask_channel)
 
     def _get_mask_channels(self):
         """ Obtain the channels from the face targets that the masks reside in from the training

--- a/plugins/train/model/_base.py
+++ b/plugins/train/model/_base.py
@@ -991,27 +991,55 @@ class _Loss():
         output_names: list
             The output names from the model
         """
-        selected_loss = self._loss_dict[self._config["loss_function"]]
+        mask_channels = self._get_mask_channels()
         for name, output_name in zip(self._names, output_names):
             if name.startswith("mask"):
                 loss_func = self._loss_dict[self._config["mask_loss_function"]]
             else:
+                loss_func = losses.LossWrapper()
+                loss_func.add_loss(self._loss_dict[self._config["loss_function"]],
+                                   mask_channel=mask_channels[0])
+
                 if (self._config["loss_function"] in self._uses_l2_reg
                         and self._config["l2_reg_term"] != 0):
-                    loss_funcs = [selected_loss, self._loss_dict["mse"]]
-                    loss_weights = [1.0, self._config["l2_reg_term"] / 100.0]
-                else:
-                    loss_funcs = [selected_loss]
-                    loss_weights = [1.0]
+                    loss_func.add_loss(self._loss_dict["mse"],
+                                       weight=self._config["l2_reg_term"] / 100.0,
+                                       mask_channel=mask_channels[0])
 
-                if self._config["penalized_mask_loss"]:
-                    loss_funcs = [losses.PenalizedLoss(loss) for loss in loss_funcs]
+                if self._config["eye_multiplier"] > 1:
+                    loss_func.add_loss(self._loss_dict["mae"],
+                                       weight=self._config["eye_multiplier"] * 1.0,
+                                       mask_channel=mask_channels[1])
 
-                loss_func = losses.LossWrapper(loss_functions=list(zip(loss_funcs, loss_weights)))
+                if self._config["mouth_multiplier"] > 1:
+                    loss_func.add_loss(self._loss_dict["mae"],
+                                       weight=self._config["mouth_multiplier"] * 1.0,
+                                       mask_channel=mask_channels[2])
 
             logger.debug("%s: (output_name: '%s', function: %s)", name, output_name, loss_func)
             self._funcs[output_name] = loss_func
         logger.debug("functions: %s", self._funcs)
+
+    def _get_mask_channels(self):
+        """ Obtain the channels from the face targets that the masks reside in from the training
+        data generator.
+
+        Returns
+        -------
+        list:
+            A list of channel indices that contain the mask for the corresponding config item
+        """
+        uses_masks = (self._config["penalized_mask_loss"],
+                      self._config["eye_multiplier"] > 1,
+                      self._config["mouth_multiplier"] > 1)
+        mask_channels = [-1 for _ in range(len(uses_masks))]
+        current_channel = 3
+        for idx, mask_required in enumerate(uses_masks):
+            if mask_required:
+                mask_channels[idx] = current_channel
+                current_channel += 1
+        logger.debug("uses_masks: %s, mask_channels: %s", uses_masks, mask_channels)
+        return mask_channels
 
 
 class State():

--- a/plugins/train/trainer/_base.py
+++ b/plugins/train/trainer/_base.py
@@ -461,9 +461,9 @@ class _Feeder():
             logger.trace("No masks to compile. Returning targets")
             return targets
 
-        if not self._model.config["penalized_mask_loss"]:
+        if not self._model.config["penalized_mask_loss"] and additional_masks is not None:
             masks = additional_masks
-        else:
+        elif additional_masks is not None:
             masks = np.concatenate((masks, additional_masks), axis=-1)
 
         for idx, tgt in enumerate(targets):

--- a/plugins/train/trainer/_base.py
+++ b/plugins/train/trainer/_base.py
@@ -101,12 +101,16 @@ class TrainerBase():
         Returns
         -------
         dict:
-            Includes the key `landmarks` if landmarks are required for training and the key `masks`
-            if the masks are required for training. """
+            Includes the key `landmarks` if landmarks are required for training, `masks` if masks
+            are required for training, `masks_eye` if eye masks are required and `masks_mouth` if
+            mouth masks are required. """
         retval = dict()
 
-        get_masks = self._model.config["learn_mask"] or self._model.config["penalized_mask_loss"]
-        if not self._model.command_line_arguments.warp_to_landmarks and not get_masks:
+        if not any([self._model.config["learn_mask"],
+                    self._model.config["penalized_mask_loss"],
+                    self._model.config["eye_multiplier"] > 1,
+                    self._model.config["mouth_multiplier"] > 1,
+                    self._model.command_line_arguments.warp_to_landmarks]):
             return retval
 
         alignments = _TrainingAlignments(self._model, self._images)
@@ -115,10 +119,17 @@ class TrainerBase():
             logger.debug("Adding landmarks to training opts dict")
             retval["landmarks"] = alignments.landmarks
 
-        if get_masks:
+        if self._model.config["learn_mask"] or self._model.config["penalized_mask_loss"]:
             logger.debug("Adding masks to training opts dict")
             retval["masks"] = alignments.masks
-        logger.debug(retval)
+
+        if self._model.config["eye_multiplier"] > 1:
+            retval["masks_eye"] = alignments.masks_eye
+
+        if self._model.config["mouth_multiplier"] > 1:
+            retval["masks_mouth"] = alignments.masks_mouth
+
+        logger.debug({key: {k: len(v) for k, v in val.items()} for key, val in retval.items()})
         return retval
 
     def _set_tensorboard(self):
@@ -407,11 +418,13 @@ class _Feeder():
         model_inputs = []
         model_targets = []
         for side in ("a", "b"):
-            side_inputs, side_targets = self._get_next(side)
-            if self._model.config["penalized_mask_loss"]:
-                side_targets = self._compile_masks(side_targets)
-                if not self._model.config["learn_mask"]:  # Remove masks from the model targets
-                    side_targets = side_targets[:-1]
+            batch = next(self._feeds[side])
+            side_inputs = batch["feed"]
+            side_targets = self._compile_mask_targets(batch["targets"],
+                                                      batch["masks"],
+                                                      batch.get("additional_masks", None))
+            if self._model.config["learn_mask"]:
+                side_targets = side_targets + [batch["masks"]]
             logger.trace("side: %s, input_shapes: %s, target_shapes: %s",
                          side, [i.shape for i in side_inputs], [i.shape for i in side_targets])
             if get_backend() == "amd":
@@ -422,35 +435,21 @@ class _Feeder():
                 model_targets.append(side_targets)
         return model_inputs, model_targets
 
-    def _get_next(self, side):
-        """ Return the next batch from the :class:`lib.training_data.TrainingDataGenerator` for
-        this feeder ready for feeding into the model.
-
-        Returns
-        -------
-        model_inputs: list
-            A list of :class:`numpy.ndarray` for feeding into the model
-        model_targets: list
-            A list of :class:`numpy.ndarray` for comparing the output of the model
-        """
-        logger.trace("Generating targets")
-        batch = next(self._feeds[side])
-        targets_use_mask = (self._model.config["learn_mask"]
-                            or self._model.config["penalized_mask_loss"])
-        model_targets = batch["targets"] + batch["masks"] if targets_use_mask else batch["targets"]
-        return batch["feed"], model_targets
-
-    @classmethod
-    def _compile_masks(cls, targets):
-        """ Compile the masks into the targets for penalized loss.
+    def _compile_mask_targets(self, targets, masks, additional_masks):
+        """ Compile the masks into the targets for penalized loss and for targeted learning.
 
         Penalized loss expects the target mask to be included for all outputs in the 4th channel
-        of the targets. The final output and final mask are always the last 2 outputs
+        of the targets. Any additional masks are placed into subsequent channels for extraction
+        by the relevant loss functions.
 
         Parameters
         ----------
         targets: list
             The targets for the model, with the mask as the final entry in the list
+        masks: list
+            The masks for the model
+        additional_masks: list or ``None``
+            Any additional masks for the model, or ``None`` if no additional masks are required
 
         Returns
         -------
@@ -458,15 +457,26 @@ class _Feeder():
             The targets for the model with the mask compiled into the 4th channel. The original
             mask is still output as the final item in the list
         """
-        masks = targets[-1]
-        for idx, tgt in enumerate(targets[:-1]):
+        if not self._model.config["penalized_mask_loss"] and additional_masks is None:
+            logger.trace("No masks to compile. Returning targets")
+            return targets
+
+        if not self._model.config["penalized_mask_loss"]:
+            masks = additional_masks
+        else:
+            masks = np.concatenate((masks, additional_masks), axis=-1)
+
+        for idx, tgt in enumerate(targets):
             tgt_dim = tgt.shape[1]
             if tgt_dim == masks.shape[1]:
                 add_masks = masks
             else:
                 add_masks = np.array([cv2.resize(mask, (tgt_dim, tgt_dim))
-                                      for mask in masks])[..., None]
+                                      for mask in masks])
+                if add_masks.ndim == 3:
+                    add_masks = add_masks[..., None]
             targets[idx] = np.concatenate((tgt, add_masks), axis=-1)
+        logger.trace("masks added to targets: %s", [tgt.shape for tgt in targets])
         return targets
 
     def generate_preview(self, do_preview):
@@ -488,7 +498,7 @@ class _Feeder():
             batch = next(self._display_feeds["preview"][side])
             self._samples[side] = batch["samples"]
             self._target[side] = batch["targets"][-1]
-            self._masks[side] = batch["masks"][0]
+            self._masks[side] = batch["masks"]
 
     def compile_sample(self, batch_size, samples=None, images=None, masks=None):
         """ Compile the preview samples for display.
@@ -547,7 +557,7 @@ class _Feeder():
             batchsizes.append(len(batch["samples"]))
             samples[side] = batch["samples"]
             images[side] = batch["targets"][-1]
-            masks[side] = batch["masks"][0]
+            masks[side] = batch["masks"]
         batchsize = min(batchsizes)
         sample = self.compile_sample(batchsize, samples=samples, images=images, masks=masks)
         return sample
@@ -1124,7 +1134,6 @@ class _TrainingAlignments():
         dict
             The face filenames as keys with the :class:`lib.faces_detect.Mask` as value.
         """
-
         masks = dict()
         for fhash, face in detected_faces.items():
             mask = face.mask[self._config["mask_type"]]
@@ -1132,6 +1141,53 @@ class _TrainingAlignments():
                                         threshold=self._config["mask_threshold"])
             for filename in self._hash_to_filenames(side, fhash):
                 masks[filename] = mask
+        return masks
+
+    @property
+    def masks_eye(self):
+        """ dict: filename mapping to zip compressed eye masks for keys "a" and "b" """
+        retval = {side: self._get_landmarks_masks(side, detected_faces, "eyes")
+                  for side, detected_faces in self._detected_faces.items()}
+        return retval
+
+    @property
+    def masks_mouth(self):
+        """ dict: filename mapping to zip compressed mouth masks for keys "a" and "b" """
+        retval = {side: self._get_landmarks_masks(side, detected_faces, "mouth")
+                  for side, detected_faces in self._detected_faces.items()}
+        return retval
+
+    def _get_landmarks_masks(self, side, detected_faces, area):
+        """ Obtain the area landmarks masks for the given area.
+
+        Parameters
+        ----------
+        side: {"a" or "b"}
+            The side currently being processed
+        detected_faces: dict
+            Key is the hash of the face, value is the corresponding
+            :class:`lib.faces_detect.DetectedFace` object
+        area: {"eyes" or "mouth"}
+            The area of the face to obtain the mask for
+
+        Returns
+        -------
+        dict
+            The face filenames as keys with the zip compressed mask as value.
+        """
+        logger.trace("side: %s, detected_faces: %s, area: %s", side, detected_faces, area)
+        masks = dict()
+        for fhash, face in detected_faces.items():
+            mask = face.get_landmark_mask(self._training_size,
+                                          area,
+                                          aligned=True,
+                                          dilation=self._training_size // 32,
+                                          blur_kernel=self._training_size // 16,
+                                          as_zip=True)
+            for filename in self._hash_to_filenames(side, fhash):
+                masks[filename] = mask
+        logger.trace("side: %s, area: %s, masks: %s",
+                     side, area, {key: type(val) for key, val in masks.items()})
         return masks
 
     # Hashes for image folders


### PR DESCRIPTION
This PR adds the ability to add weighting to the mouth and eye area of the face.

To be honest, I'm not sure how much of an impact this really has, but it definitely shows a difference at the beginning of training and the theory behind it is sound. It also does not appear to be detrimental.

Also introduces a LossWrapper class for allowing multiple weighted losses on single outputs. PenalizedLoss class has been removed and merged into this new class.