### PR TITLE
Bugfix: Required tensorflow docker image update to 2.2.1

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.2.0-gpu-py3
+FROM tensorflow/tensorflow:2.2.1-gpu-py3
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
There is now no docker image tagged for tensorflow/tensorflow:2.2.0-gpu-py3, bumped it to 2.2.1

Docker hub: https://hub.docker.com/r/tensorflow/tensorflow/tags?page=1&name=2.2.0-gpu-py3