### PR TITLE
Bugfix: Fix tensorflow cpu docker image

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,10 +1,8 @@
 FROM tensorflow/tensorflow:2.2.1-py3
 
-RUN apt-get update \
-  && apt-get install -y software-properties-common \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 \
+RUN apt-get update -qq -y \
+ && apt-get install -y software-properties-common \
+ && add-apt-repository -y ppa:jonathonf/ffmpeg-4 \
  && apt-get update -qq -y \
  && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk ffmpeg git \
  && apt-get clean \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,5 +1,9 @@
 FROM tensorflow/tensorflow:2.2.1-py3
 
+RUN apt-get update \
+  && apt-get install -y software-properties-common \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 \
  && apt-get update -qq -y \
  && apt-get install -y libsm6 libxrender1 libxext-dev python3-tk ffmpeg git \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.2.0-py3
+FROM tensorflow/tensorflow:2.2.1-py3
 
 RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 \
  && apt-get update -qq -y \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,5 +1,8 @@
 FROM tensorflow/tensorflow:2.2.1-py3
 
+# To disable tzdata and others from asking for input
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update -qq -y \
  && apt-get install -y software-properties-common \
  && add-apt-repository -y ppa:jonathonf/ffmpeg-4 \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,5 +1,6 @@
 FROM tensorflow/tensorflow:2.2.1-gpu-py3
 
+# To disable tzdata and others from asking for input
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 \


### PR DESCRIPTION
Changes required to make the cpu image build:

1. Install missing package required for `add-apt-repository` to work
1. Disable interactive input to stop `tzdata` from stopping the image build.
1. There is no image tagged 2.2.0-py3. [2.2.1-py3](https://hub.docker.com/layers/tensorflow/tensorflow/2.2.1-py3/images/sha256-c1503bb7763bd425d41533409ca7218d5a44b3b78e530b978d7ff3085283b0e3?context=explore)

Related ticket for gpu: #1078