### PR TITLE
Update to TF2.3

### DIFF
--- a/lib/cli/launcher.py
+++ b/lib/cli/launcher.py
@@ -53,10 +53,10 @@ class ScriptExecutor():  # pylint:disable=too-few-public-methods
         Raises
         ------
         FaceswapError
-            If Tensorflow is not found, or is not between versions 2.2 and 2.2
+            If Tensorflow is not found, or is not between versions 2.3 and 2.3
         """
-        min_ver = 2.2
-        max_ver = 2.2
+        min_ver = 2.3
+        max_ver = 2.3
         try:
             # Ensure tensorflow doesn't pin all threads to one core when using Math Kernel Library
             os.environ["TF_MIN_GPU_MULTIPROCESSOR_COUNT"] = "4"

--- a/lib/gui/stats.py
+++ b/lib/gui/stats.py
@@ -17,7 +17,7 @@ from threading import Event
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python import errors_impl as tf_errors  # pylint:disable=no-name-in-module
+from tensorflow.python.framework import errors_impl as tf_errors
 from tensorflow.core.util import event_pb2
 from lib.serializer import get_serializer
 

--- a/lib/logger.py
+++ b/lib/logger.py
@@ -110,10 +110,17 @@ class FaceswapFormatter(logging.Formatter):
         record: :class:`logging.LogRecord`
             The log record to check for rewriting
         """
-        if record.levelno == 30 and (record.funcName == "_tfmw_add_deprecation_warning" or
-                                     record.module in ("deprecation", "deprecation_wrapper")):
+        if record.levelno == 30 and record.funcName == "warn" and record.module == "ag_logging":
+            # TF 2.3 in Conda is imported with the wrong gast(0.4 when 0.3.3 should be used). This
+            # causes warnings in autograph. They don't appear to impact performance so de-elevate
+            # warning to debug
             record.levelno = 10
             record.levelname = "DEBUG"
+
+        # Keras Deprecations. Not currently required
+        # if record.levelno == 30 and (record.funcName == "_tfmw_add_deprecation_warning" or
+        #                              record.module in ("deprecation", "deprecation_wrapper")):
+
         return record
 
 

--- a/lib/logger.py
+++ b/lib/logger.py
@@ -79,7 +79,7 @@ class FaceswapFormatter(logging.Formatter):
         record.message = record.getMessage()
         record = self._rewrite_warnings(record)
         # strip newlines
-        if "\n" in record.message or "\r" in record.message:
+        if record.levelno < 30 and ("\n" in record.message or "\r" in record.message):
             record.message = record.message.replace("\n", "\\n").replace("\r", "\\r")
 
         if self.usesTime():
@@ -117,9 +117,11 @@ class FaceswapFormatter(logging.Formatter):
             record.levelno = 10
             record.levelname = "DEBUG"
 
-        # Keras Deprecations. Not currently required
-        # if record.levelno == 30 and (record.funcName == "_tfmw_add_deprecation_warning" or
-        #                              record.module in ("deprecation", "deprecation_wrapper")):
+        if record.levelno == 30 and (record.funcName == "_tfmw_add_deprecation_warning" or
+                                     record.module in ("deprecation", "deprecation_wrapper")):
+            # Keras Deprecations.
+            record.levelno = 10
+            record.levelname = "DEBUG"
 
         return record
 
@@ -278,7 +280,7 @@ def _stream_handler(loglevel, is_gui):
 
 
 def _crash_handler(log_format):
-    """ Add a handler that stores the last 100 debug lines to :attr:'_debug_buffer' for use in
+    """ Add a handler that stores the last 100 debug lines to :attr:'_DEBUG_BUFFER' for use in
     crash reports.
 
     Parameters
@@ -291,7 +293,7 @@ def _crash_handler(log_format):
     :class:`logging.StreamHandler`
         The crash log handler
     """
-    log_crash = logging.StreamHandler(_debug_buffer)
+    log_crash = logging.StreamHandler(_DEBUG_BUFFER)
     log_crash.setFormatter(log_format)
     log_crash.setLevel(logging.DEBUG)
     return log_crash
@@ -318,7 +320,7 @@ def get_loglevel(loglevel):
 
 
 def crash_log():
-    """ On a crash, write out the contents of :func:`_debug_buffer` containing the last 100 lines
+    """ On a crash, write out the contents of :func:`_DEBUG_BUFFER` containing the last 100 lines
     of debug messages to a crash report in the root Faceswap folder.
 
     Returns
@@ -329,7 +331,7 @@ def crash_log():
     original_traceback = traceback.format_exc()
     path = os.path.dirname(os.path.realpath(sys.argv[0]))
     filename = os.path.join(path, datetime.now().strftime("crash_report.%Y.%m.%d.%H%M%S%f.log"))
-    freeze_log = list(_debug_buffer)
+    freeze_log = list(_DEBUG_BUFFER)
     try:
         from lib.sysinfo import sysinfo  # pylint:disable=import-outside-toplevel
     except Exception:  # pylint:disable=broad-except
@@ -342,13 +344,13 @@ def crash_log():
     return filename
 
 
-_old_factory = logging.getLogRecordFactory()
+_OLD_FACTORY = logging.getLogRecordFactory()
 
 
 def _faceswap_logrecord(*args, **kwargs):
     """ Add a flag to :class:`logging.LogRecord` to not strip formatting from particular
     records. """
-    record = _old_factory(*args, **kwargs)
+    record = _OLD_FACTORY(*args, **kwargs)
     record.strip_spaces = True
     return record
 
@@ -359,4 +361,4 @@ logging.setLogRecordFactory(_faceswap_logrecord)
 logging.setLoggerClass(FaceswapLogger)
 
 # Stores the last 100 debug messages
-_debug_buffer = RollingBuffer(maxlen=100)
+_DEBUG_BUFFER = RollingBuffer(maxlen=100)

--- a/lib/model/losses_plaid.py
+++ b/lib/model/losses_plaid.py
@@ -73,7 +73,7 @@ class DSSIMObjective():
         self.dim_ordering = K.image_data_format()
 
     @staticmethod
-    def __int_shape(input_tensor):
+    def _int_shape(input_tensor):
         """ Returns the shape of tensor or variable as a tuple of int or None entries.
 
         Parameters
@@ -110,8 +110,8 @@ class DSSIMObjective():
         """
 
         kernel = [self.kernel_size, self.kernel_size]
-        y_true = K.reshape(y_true, [-1] + list(self.__int_shape(y_pred)[1:]))
-        y_pred = K.reshape(y_pred, [-1] + list(self.__int_shape(y_pred)[1:]))
+        y_true = K.reshape(y_true, [-1] + list(self._int_shape(y_pred)[1:]))
+        y_pred = K.reshape(y_pred, [-1] + list(self._int_shape(y_pred)[1:]))
         patches_pred = self.extract_image_patches(y_pred,
                                                   kernel,
                                                   kernel,

--- a/lib/model/losses_tf.py
+++ b/lib/model/losses_tf.py
@@ -71,7 +71,7 @@ class DSSIMObjective(tf.keras.losses.Loss):
         self.dim_ordering = K.image_data_format()
 
     @staticmethod
-    def __int_shape(input_tensor):
+    def _int_shape(input_tensor):
         """ Returns the shape of tensor or variable as a tuple of int or None entries.
 
         Parameters
@@ -108,8 +108,8 @@ class DSSIMObjective(tf.keras.losses.Loss):
         """
 
         kernel = [self.kernel_size, self.kernel_size]
-        y_true = K.reshape(y_true, [-1] + list(self.__int_shape(y_pred)[1:]))
-        y_pred = K.reshape(y_pred, [-1] + list(self.__int_shape(y_pred)[1:]))
+        y_true = K.reshape(y_true, [-1] + list(self._int_shape(y_pred)[1:]))
+        y_pred = K.reshape(y_pred, [-1] + list(self._int_shape(y_pred)[1:]))
         patches_pred = self.extract_image_patches(y_pred,
                                                   kernel,
                                                   kernel,

--- a/plugins/extract/_base.py
+++ b/plugins/extract/_base.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 
-from tensorflow.python import errors_impl as tf_errors  # pylint:disable=no-name-in-module
+from tensorflow.python.framework import errors_impl as tf_errors
 
 from lib.multithreading import MultiThread
 from lib.queue_manager import queue_manager

--- a/plugins/extract/align/_base.py
+++ b/plugins/extract/align/_base.py
@@ -17,7 +17,7 @@ For each source item, the plugin must pass a dict to finalize containing:
 import cv2
 import numpy as np
 
-from tensorflow.python import errors_impl as tf_errors  # pylint:disable=no-name-in-module
+from tensorflow.python.framework import errors_impl as tf_errors
 
 from lib.utils import get_backend, FaceswapError
 from plugins.extract._base import Extractor, logger, ExtractMedia

--- a/plugins/extract/detect/_base.py
+++ b/plugins/extract/detect/_base.py
@@ -18,7 +18,7 @@ To get a :class:`~lib.align.DetectedFace` object use the function:
 import cv2
 import numpy as np
 
-from tensorflow.python import errors_impl as tf_errors  # pylint:disable=no-name-in-module
+from tensorflow.python.framework import errors_impl as tf_errors
 
 from lib.align import DetectedFace
 from lib.utils import get_backend, FaceswapError

--- a/plugins/extract/detect/s3fd.py
+++ b/plugins/extract/detect/s3fd.py
@@ -8,7 +8,6 @@ https://github.com/1adrianb/face-alignment
 
 from scipy.special import logsumexp
 import numpy as np
-import tensorflow as tf
 import keras  # pylint:disable=import-error
 import keras.backend as K  # pylint:disable=import-error
 from keras.layers import Concatenate, Conv2D, Input, Maximum, MaxPooling2D, ZeroPadding2D

--- a/plugins/extract/detect/s3fd.py
+++ b/plugins/extract/detect/s3fd.py
@@ -176,17 +176,6 @@ class SliceO2K(keras.layers.Layer):
             input_shape[a_x] = (min(size, end) - start) // steps
         return tuple(input_shape)
 
-    # The following decorator hides the following warning for tf2.3:
-    #
-    # AutoGraph could not transform <bound method SliceO2K.call of
-    # <plugins.extract.detect.s3fd.SliceO2K object at 0x0000024F3C771100>> and will run it as-is.
-    # Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on
-    # Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.
-    # Cause: module 'gast' has no attribute 'Index'\nTo silence this warning, decorate the function
-    # with @tf.autograph.experimental.do_not_convert
-    #
-    # TODO Get to root cause of error and fix
-    @tf.autograph.experimental.do_not_convert
     def call(self, inputs, **kwargs):  # pylint:disable=unused-argument
         """This is where the layer's logic lives.
 

--- a/plugins/extract/mask/_base.py
+++ b/plugins/extract/mask/_base.py
@@ -16,7 +16,7 @@ For each source item, the plugin must pass a dict to finalize containing:
 import cv2
 import numpy as np
 
-from tensorflow.python import errors_impl as tf_errors  # pylint:disable=no-name-in-module
+from tensorflow.python.framework import errors_impl as tf_errors
 
 from lib.align import AlignedFace
 from lib.utils import get_backend, FaceswapError

--- a/plugins/train/trainer/_base.py
+++ b/plugins/train/trainer/_base.py
@@ -18,7 +18,7 @@ import cv2
 import numpy as np
 
 import tensorflow as tf
-from tensorflow.python import errors_impl as tf_errors  # pylint:disable=no-name-in-module
+from tensorflow.python.framework import errors_impl as tf_errors
 from tqdm import tqdm
 
 from lib.align import Alignments, DetectedFace

--- a/requirements_amd.txt
+++ b/requirements_amd.txt
@@ -1,3 +1,3 @@
 -r _requirements_base.txt
-tensorflow>=2.2.0,<2.3.0
+tensorflow>=2.3.0,<2.4.0
 plaidml-keras==0.7.0

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -1,2 +1,2 @@
 -r _requirements_base.txt
-tensorflow>=2.2.0,<2.3.0
+tensorflow>=2.3.0,<2.4.0

--- a/requirements_nvidia.txt
+++ b/requirements_nvidia.txt
@@ -1,2 +1,2 @@
 -r _requirements_base.txt
-tensorflow-gpu>=2.2.0,<2.3.0
+tensorflow-gpu>=2.3.0,<2.4.0

--- a/setup.py
+++ b/setup.py
@@ -651,9 +651,9 @@ class Install():
         # removed, but won't hurt to take them out of pip and put in Conda
         remove_packages = ["urllib3", "pyasn1", "idna", "chardet", "rsa", "requests",
                            "pyasn1-modules", "oauthlib", "cachetools", "requests-oauthlib",
-                           "google-auth", "werkzeug", "tensorboard-plugin-wit", "protobuf", 
-                           "numpy", "markdown", "grpcio", "google-auth-oauthlib", "absl-py", 
-                           "wrapt", "termcolor", "tensorflow-gpu-estimator", "tensorboard", 
+                           "google-auth", "werkzeug", "tensorboard-plugin-wit", "protobuf",
+                           "numpy", "markdown", "grpcio", "google-auth-oauthlib", "absl-py",
+                           "wrapt", "termcolor", "tensorflow-gpu-estimator", "tensorboard",
                            "opt-einsum", "keras-preprocessing", "h5py", "google-pasta", "gast",
                            "astunparse", "tensorflow-gpu"]
         self.output.info("Uninstalling Pip Tensorflow 2.2")
@@ -768,7 +768,7 @@ class Install():
     def _tensorflow_dependency_install(self):
         """ Install the Cuda/cuDNN dependencies from Conda when tensorflow is not available
         in Conda.
-        
+
         This was used whilst Tensorflow 2.2 was not available for Windows in Conda. It is kept
         here in case it is required again in the future.
         """

--- a/tests/startup_test.py
+++ b/tests/startup_test.py
@@ -25,5 +25,5 @@ def test_backend(dummy):  # pylint:disable=unused-argument
 def test_keras(dummy):  # pylint:disable=unused-argument
     """ Sanity check to ensure that tensorflow keras is being used for CPU and standard
     keras for AMD. """
-    assert ((_BACKEND == "cpu" and keras.__version__.endswith("-tf")) or
-            (_BACKEND == "amd" and not keras.__version__.endswith("-tf")))
+    assert ((_BACKEND == "cpu" and keras.__version__ == "2.4.0") or
+            (_BACKEND == "amd" and not keras.__version__ == "2.2.4"))

--- a/tests/startup_test.py
+++ b/tests/startup_test.py
@@ -26,4 +26,4 @@ def test_keras(dummy):  # pylint:disable=unused-argument
     """ Sanity check to ensure that tensorflow keras is being used for CPU and standard
     keras for AMD. """
     assert ((_BACKEND == "cpu" and keras.__version__ == "2.4.0") or
-            (_BACKEND == "amd" and not keras.__version__ == "2.2.4"))
+            (_BACKEND == "amd" and keras.__version__ == "2.2.4"))


### PR DESCRIPTION
Updates the minimum spec to Tensorflow 2.3

This brings both Windows and Linux in line with TF2.3 available on Conda.

NB: There is an issue with TF2.3 with Python 3.8. TF requires `gast==0.3.3` but only `0.4` is available in Python 3.8. This generates warnings for Autograph. On the face of it, this does not cause any performance issues, so the warnings have been suppressed.

Updates for API changes, mostly around Tensorboard.

