### PR TITLE
Adding some defensive code to better identify which image is causing …

### DIFF
--- a/lib/image.py
+++ b/lib/image.py
@@ -381,8 +381,8 @@ def read_image_meta(filename):
         try:
             chunk = infile.read(8)
         except PermissionError:
-            logger.error(f"PermissionError while reading {filename}")
-        if b"\x89PNG\r\n\x1a\n" != chunk:
+            raise PermissionError(f"PermissionError while reading: {filename}")
+        if chunk  != b"\x89PNG\r\n\x1a\n":
             raise ValueError(f"Invalid header found in png: {filename}")
         while True:
             chunk = infile.read(8)

--- a/lib/image.py
+++ b/lib/image.py
@@ -382,8 +382,10 @@ def read_image_meta(filename):
             chunk = infile.read(8)
         except PermissionError:
             raise PermissionError(f"PermissionError while reading: {filename}")
-        if chunk  != b"\x89PNG\r\n\x1a\n":
+
+        if chunk != b"\x89PNG\r\n\x1a\n":
             raise ValueError(f"Invalid header found in png: {filename}")
+
         while True:
             chunk = infile.read(8)
             length, field = struct.unpack(">I4s", chunk)

--- a/lib/image.py
+++ b/lib/image.py
@@ -378,8 +378,11 @@ def read_image_meta(filename):
         retval["height"], retval["width"] = img.shape[:2]
         return retval
     with open(filename, "rb") as infile:
-        chunk = infile.read(8)
-        if chunk != b"\x89PNG\r\n\x1a\n":
+        try:
+            chunk = infile.read(8)
+        except PermissionError:
+            logger.error(f"PermissionError while reading {filename}")
+        if b"\x89PNG\r\n\x1a\n" != chunk:
             raise ValueError(f"Invalid header found in png: {filename}")
         while True:
             chunk = infile.read(8)


### PR DESCRIPTION
Adding some defensive code to better identify which image is causing an issue when permission error is encountered.

A previous functional training set somehow had two images that became corrupted, there was nothing in logs or stdout to indicate which image(s) were causing an issue. 