### PR TITLE
Update Dockerfile.gpu for the latest Tensorflow

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,7 +1,8 @@
-FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04
+FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 
 #install python3.8
 RUN apt-get update
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt install software-properties-common -y
 RUN add-apt-repository ppa:deadsnakes/ppa -y
 RUN apt-get update


### PR DESCRIPTION
The latest TensorFlow is supported only CUDA 11.0 and cuDNN SDK 8.0

> Software requirements
> The following NVIDIA® software must be installed on your system:
>
> - NVIDIA® GPU drivers —CUDA® 11.0 requires 450.x or higher.
> - CUDA® Toolkit —TensorFlow supports CUDA® 11 (TensorFlow >= 2.4.0)
> - CUPTI ships with the CUDA® Toolkit.
> - cuDNN SDK 8.0.4 cuDNN versions).
> - (Optional) TensorRT 6.0 to improve latency and throughput for inference on some models.

https://www.tensorflow.org/install/gpu