### PR TITLE
Add a new sorting/grouping feature based on black pixels in images

### DIFF
--- a/tools/sort/cli.py
+++ b/tools/sort/cli.py
@@ -78,7 +78,8 @@ class SortArgs(FaceSwapArgs):
                    "faces further from the camera and from lower resolution sources will be "
                    "sorted last."
                    "\nL|'black-pixels': Sort images by their number of black pixels. Useful when "
-                   "faces are near borders and a large part of the image is black.\nDefault: face")))
+                   "faces are near borders and a large part of the image is black."
+                   "\nDefault: face")))
         argument_list.append(dict(
             opts=('-k', '--keep'),
             action='store_true',
@@ -136,16 +137,17 @@ class SortArgs(FaceSwapArgs):
             dest='num_bins',
             group=_("output"),
             default=5,
-            help=_("Integer value. Number of folders that will be used to group by blur, face-yaw "
-                   "and black-pixels. For blur folder 0 will be the least blurry, while the last "
-                   "folder will be the blurriest. For face-yaw the number of bins is by how much "
-                   "180 degrees is divided. So if you use 18, then each folder will be a 10 degree "
-                   "increment. Folder 0 will contain faces looking the most to the left whereas "
-                   "the last folder will contain the faces looking the most to the right. If the "
-                   "number of images doesn't divide evenly into the number of bins, the remaining "
-                   "images get put in the last bin. For black-pixels it represents the divider of "
-                   "the percentage of black pixels. For 10, first folder will have the faces with "
-                   "0 to 10% black pixels, second 11 to 20%, etc. Default value: 5")))
+            help=_("Integer value. Number of folders that will be used to group by blur, "
+                   "face-yaw and black-pixels. For blur folder 0 will be the least blurry, while "
+                   "the last folder will be the blurriest. For face-yaw the number of bins is by "
+                   "how much 180 degrees is divided. So if you use 18, then each folder will be "
+                   "a 10 degree increment. Folder 0 will contain faces looking the most to the "
+                   "left whereas the last folder will contain the faces looking the most to the "
+                   "right. If the number of images doesn't divide evenly into the number of "
+                   "bins, the remaining images get put in the last bin. For black-pixels it "
+                   "represents the divider of the percentage of black pixels. For 10, first "
+                   "folder will have the faces with 0 to 10% black pixels, second 11 to 20%, "
+                   "etc. Default value: 5")))
         argument_list.append(dict(
             opts=('-l', '--log-changes'),
             action='store_true',

--- a/tools/sort/cli.py
+++ b/tools/sort/cli.py
@@ -45,7 +45,7 @@ class SortArgs(FaceSwapArgs):
             type=str,
             choices=("blur", "blur-fft", "distance", "face", "face-cnn", "face-cnn-dissim",
                      "face-yaw", "hist", "hist-dissim", "color-gray", "color-luma", "color-green",
-                     "color-orange", "size"),
+                     "color-orange", "size", "black-pixels"),
             dest='sort_method',
             group=_("sort settings"),
             default="face",
@@ -76,7 +76,9 @@ class SortArgs(FaceSwapArgs):
                    "\nL|'size': Sort images by their size in the original frame. Faces closer to "
                    "the camera and from higher resolution sources will be sorted first, whilst "
                    "faces further from the camera and from lower resolution sources will be "
-                   "sorted last.\nDefault: face")))
+                   "sorted last."
+                   "\nL|'black-pixels': Sort images by their number of black pixels. Useful when "
+                   "faces are near borders and a large part of the image is black.\nDefault: face")))
         argument_list.append(dict(
             opts=('-k', '--keep'),
             action='store_true',
@@ -119,7 +121,7 @@ class SortArgs(FaceSwapArgs):
             opts=('-g', '--group-by'),
             action=Radio,
             type=str,
-            choices=("blur", "blur-fft", "face-cnn", "face-yaw", "hist"),
+            choices=("blur", "blur-fft", "face-cnn", "face-yaw", "hist", "black-pixels"),
             dest='group_method',
             group=_("output"),
             default="hist",
@@ -134,14 +136,16 @@ class SortArgs(FaceSwapArgs):
             dest='num_bins',
             group=_("output"),
             default=5,
-            help=_("Integer value. Number of folders that will be used to group by blur and "
-                   "face-yaw. For blur folder 0 will be the least blurry, while the last folder "
-                   "will be the blurriest. For face-yaw the number of bins is by how much 180 "
-                   "degrees is divided. So if you use 18, then each folder will be a 10 degree "
+            help=_("Integer value. Number of folders that will be used to group by blur, face-yaw "
+                   "and black-pixels. For blur folder 0 will be the least blurry, while the last "
+                   "folder will be the blurriest. For face-yaw the number of bins is by how much "
+                   "180 degrees is divided. So if you use 18, then each folder will be a 10 degree "
                    "increment. Folder 0 will contain faces looking the most to the left whereas "
                    "the last folder will contain the faces looking the most to the right. If the "
                    "number of images doesn't divide evenly into the number of bins, the remaining "
-                   "images get put in the last bin. Default value: 5")))
+                   "images get put in the last bin. For black-pixels it represents the divider of "
+                   "the percentage of black pixels. For 10, first folder will have the faces with "
+                   "0 to 10% black pixels, second 11 to 20%, etc. Default value: 5")))
         argument_list.append(dict(
             opts=('-l', '--log-changes'),
             action='store_true',

--- a/tools/sort/sort.py
+++ b/tools/sort/sort.py
@@ -719,7 +719,8 @@ class Sort():
             temp_list = list(zip(filename_list, histograms))
         elif group_method == 'group_black_pixels':
             filename_list, image_list = self._get_images()
-            black_pixels = [np.all(img == [0, 0, 0], axis=2).sum()/img.size*100*3 for img in image_list]
+            black_pixels = [np.ndarray.all(img == [0, 0, 0], axis=2).sum()/img.size*100*3
+                            for img in image_list]
             temp_list = list(zip(filename_list, black_pixels))
         else:
             raise ValueError("{} group_method not found.".format(group_method))

--- a/tools/sort/sort.py
+++ b/tools/sort/sort.py
@@ -407,6 +407,25 @@ class Sort():
         logger.info("Sorting...")
         return sorted(img_list, key=lambda x: x[1], reverse=True)
 
+    def sort_black_pixels(self):
+        """ Sort by percentage of black pixels """
+        logger.info("Sorting by percentage of black pixels...")
+
+        """ Calculate the sum of black pixels, get the percentage X 3 channels """
+        img_list = [(filename, np.ndarray.all(image == [0, 0, 0], axis=2).sum()/image.size*100*3)
+                    for filename, image, _ in tqdm(self._loader.load(),
+                                                   desc="Calculating black pixels",
+                                                   total=self._loader.count,
+                                                   leave=False)]
+        img_list_len = len(img_list)
+        for i in tqdm(range(0, img_list_len - 1), desc="Comparing black pixels", file=sys.stdout):
+            for j in range(0, img_list_len-i-1):
+                if img_list[j][1] > img_list[j+1][1]:
+                    temp = img_list[j]
+                    img_list[j] = img_list[j+1]
+                    img_list[j+1] = temp
+        return img_list
+
     # Methods for grouping
     def group_blur(self, img_list):
         """ Group into bins by blur """
@@ -522,6 +541,25 @@ class Sort():
         # If remainder is 0, nothing gets added to the last bin.
         for i in range(1, remainder + 1):
             bins[-1].append(img_list[-i][0])
+
+        return bins
+
+    def group_black_pixels(self, img_list):
+        """ Group into bins by percentage of black pixels
+        :type img_list: (str, float)
+        """
+        logger.info("Grouping by percentage of black pixels...")
+
+        # Starting the binning process
+        bins = [[] for _ in range(self._args.num_bins)]
+        # Get edges of bins from 0 to 100
+        bins_edges = self._near_split(100, self._args.num_bins)
+        # Get the proper bin number for each img order
+        img_bins = np.digitize([x[1] for x in img_list], bins_edges, right=True)
+
+        # Place imgs in bins
+        for i, b in enumerate(img_bins):
+            bins[b].append(img_list[i][0])
 
         return bins
 
@@ -679,10 +717,25 @@ class Sort():
             filename_list, image_list = self._get_images()
             histograms = [cv2.calcHist([img], [0], None, [256], [0, 256]) for img in image_list]
             temp_list = list(zip(filename_list, histograms))
+        elif group_method == 'group_black_pixels':
+            filename_list, image_list = self._get_images()
+            black_pixels = [np.all(img == [0, 0, 0], axis=2).sum()/img.size*100*3 for img in image_list]
+            temp_list = list(zip(filename_list, black_pixels))
         else:
             raise ValueError("{} group_method not found.".format(group_method))
 
         return self.splice_lists(img_list, temp_list)
+
+    @staticmethod
+    def _near_split(x, num_bins):
+        quotient, remainder = divmod(x, num_bins)
+        seps = [quotient + 1] * remainder + [quotient] * (num_bins - remainder)
+        uplimit = 0
+        bins = [0]
+        for n in seps:
+            bins.append(uplimit+n)
+            uplimit += n
+        return bins
 
     @staticmethod
     def _convert_color(imgs, same_size, method):


### PR DESCRIPTION
Context:
- Faces are quite often moving and can get near borders of the image.
- Because of that, the face image has the out of bound part replaced by black pixels.
- Some are still good for training but others not. Also, one might want to keep an alignment file with the near borders faces but excluded (some of) them for training.
- Having to manually move/delete those images in a dataset of thousands of them is painful and prone to mistakes.
- Thus, having a way to sort and group those images would be helpful. At least, it is for me :-)

Added features:
- A new option in Tools/Sort for both Sort and Group By called Black-Pixels.
- Sort feature: calculates the percentage of black pixels in each images and sort them from 0 to 100%.
- Group By feature: Uses the Bins slider number selected and creates 100/Bins folders with the images percentage of black pixels. ie. a Bins of 5 will create 20 folders with the first one containing images with 0-5% of black pixels, the second one with 6-10%, etc. A static method as been added for the rounding error.