### PR TITLE
trainer: add support for non-interactive jobs

### DIFF
--- a/lib/keypress.py
+++ b/lib/keypress.py
@@ -34,7 +34,7 @@ class KBHit:
     """ Creates a KBHit object that you can call to do various keyboard things. """
     def __init__(self, is_gui=False):
         self.is_gui = is_gui
-        if os.name == "nt" or self.is_gui:
+        if os.name == "nt" or self.is_gui or not sys.stdout.isatty():
             pass
         else:
             # Save the terminal settings
@@ -51,7 +51,7 @@ class KBHit:
 
     def set_normal_term(self):
         """ Resets to normal terminal.  On Windows this is a no-op. """
-        if os.name == "nt" or self.is_gui:
+        if os.name == "nt" or self.is_gui or not sys.stdout.isatty():
             pass
         else:
             termios.tcsetattr(self.file_desc, termios.TCSAFLUSH, self.old_term)
@@ -59,7 +59,7 @@ class KBHit:
     def getch(self):
         """ Returns a keyboard character after kbhit() has been called.
             Should not be called in the same program as getarrow(). """
-        if self.is_gui and os.name != "nt":
+        if self.is_gui and os.name != "nt" or not sys.stdout.isatty():
             return None
         if os.name == "nt":
             return msvcrt.getch().decode("utf-8")
@@ -73,7 +73,7 @@ class KBHit:
         3 : left
         Should not be called in the same program as getch(). """
 
-        if self.is_gui:
+        if self.is_gui or not sys.stdout.isatty():
             return None
         if os.name == "nt":
             msvcrt.getch()  # skip 0xE0
@@ -87,7 +87,7 @@ class KBHit:
 
     def kbhit(self):
         """ Returns True if keyboard character was hit, False otherwise. """
-        if self.is_gui and os.name != "nt":
+        if self.is_gui and os.name != "nt" or not sys.stdout.isatty():
             return None
         if os.name == "nt":
             return msvcrt.kbhit()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -360,9 +360,10 @@ class Train():  # pylint:disable=too-few-public-methods
         logger.info("  Starting")
         if self._args.preview:
             logger.info("  Using live preview")
-        logger.info("  Press '%s' to save and quit",
+        if sys.stdout.isatty():
+            logger.info("  Press '%s' to save and quit",
                     "Stop" if self._args.redirect_gui or self._args.colab else "ENTER")
-        if not self._args.redirect_gui and not self._args.colab:
+        if not self._args.redirect_gui and not self._args.colab and sys.stdout.isatty():
             logger.info("  Press 'S' to save model weights immediately")
         logger.info("===================================================")
 


### PR DESCRIPTION
Add support for training in non-interactive shell environment such as Sun Grid Engine, Univa Grid Engine and others.

Tested on Univa Grid Engine.

Reference: https://stackoverflow.com/questions/967369/python-find-out-if-running-in-shell-or-not-e-g-sun-grid-engine-queue.