### PR TITLE
Bisenet-FP - Improved weights for masker

### DIFF
--- a/plugins/extract/mask/bisenet_fp.py
+++ b/plugins/extract/mask/bisenet_fp.py
@@ -35,7 +35,6 @@ class Mask(Masker):
         self.vram_per_batch = 64
         self.batchsize = self.config["batch-size"]
 
-        self._is_faceswap = self.config["weights"] == "faceswap"
         self._segment_indices = self._get_segment_indices()
         self._storage_centering = "head" if self.config["include_hair"] else "face"
         # Separate storage for face and head masks

--- a/plugins/extract/mask/bisenet_fp_defaults.py
+++ b/plugins/extract/mask/bisenet_fp_defaults.py
@@ -63,6 +63,18 @@ _DEFAULTS = {
         group="settings",
         gui_radio=False,
         fixed=True),
+    "weights": dict(
+        default="faceswap",
+        info="The trained weights to use.\n"
+             "\n\tfaceswap - Weights trained on wildly varied Faceswap extracted data to better "
+             "handle varying conditions, obstructions, glasses and multiple targets within a "
+             "single extracted image."
+             "\n\toriginal - The original weights trained on the CelebAMask-HQ dataset.",
+        choices=["faceswap", "original"],
+        datatype=str,
+        group="settings",
+        gui_radio=True,
+    ),
     "include_ears": dict(
         default=False,
         info="Whether to include ears within the face mask.",
@@ -77,8 +89,10 @@ _DEFAULTS = {
     ),
     "include_glasses": dict(
         default=True,
-        info="Whether to include glasses within the face mask. NB: excluding glasses will mask "
-             "out the lenses as well as the frames.",
+        info="Whether to include glasses within the face mask.\n\tFor 'original' weights "
+             "excluding glasses will mask out the lenses as well as the frames.\n\tFor 'faceswap' "
+             "weights, the model has been trained to mask out lenses if eyes cannot be seen (i.e. "
+             "dark sunglasses) or just the frames if the eyes can be seen. ",
         datatype=bool,
         group="settings"
     ),


### PR DESCRIPTION
The following pull-request allows for the use of custom trained weights for the Bisenet-FP Mask.

The dataset of 40k faces has been built from a wide variety of posed and in the wild images. These have been manually annotated over several months to handle:
- many varieties of real obstructions
- difficult/varied conditions + poses
- glasses (mask out frames, keep lenses)
- dark sunglasses (mask out frames + lenses)
- multiple targets within a single extracted image.

This dataset will continue to be grown over time and will be used to create new and more improved maskers. Whilst this solution is by no means perfect, it is vastly improved over any existing masking solutions.

NB: This Pull Request does not include the actual weights file. This will be going to Patreons first for a timed exclusive, but the weights will eventually be made available for use in the main code.

### Glasses + Sunglasses:
![gls](https://user-images.githubusercontent.com/36920800/160387537-1ce15fda-4da8-41c8-9d74-57249b756d4c.gif)

### Ignoring the non-target face: 
![fac](https://user-images.githubusercontent.com/36920800/160387642-6bdd4caa-c7bb-4f4d-860a-8d987498830a.gif)

### Multiple obstruction types:
![obs](https://user-images.githubusercontent.com/36920800/160387649-0ad78edb-4dc0-42c2-b455-68ee8a5322a3.gif)

