### PR TITLE
Some Apple Silicion setup fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -191,7 +191,7 @@ $ source ~/miniforge3/bin/activate
 ## Setup
 ### Create and Activate the Environment
 ```sh
-$ conda env create -n faceswap python=3.9
+$ conda create --name faceswap python=3.9
 $ conda activate faceswap
 ```
 

--- a/requirements/_requirements_base.txt
+++ b/requirements/_requirements_base.txt
@@ -15,4 +15,3 @@ ffmpy==0.2.3
 nvidia-ml-py<11.515
 typing-extensions
 pywin32>=228 ; sys_platform == "win32"
-pynvx==1.0.0 ; sys_platform == "darwin"

--- a/requirements/requirements_apple_silicon.txt
+++ b/requirements/requirements_apple_silicon.txt
@@ -1,3 +1,4 @@
 tensorflow-macos>=2.8.0,<2.9.0
-tensorflow-metal>=2.8.0,<2.9.0
+tensorflow-deps>=2.8.0,<2.9.0
+tensorflow-metal>=0.4.0,<0.5.0
 libblas  # Conda only

--- a/requirements/requirements_nvidia.txt
+++ b/requirements/requirements_nvidia.txt
@@ -1,2 +1,3 @@
 -r _requirements_base.txt
 tensorflow-gpu>=2.4.0,<2.9.0
+pynvx==1.0.0 ; sys_platform == "darwin"

--- a/setup.py
+++ b/setup.py
@@ -729,7 +729,7 @@ class Install():
                 pkg = pkg[0]
             if version:
                 pkg = f"{pkg}{','.join(''.join(spec) for spec in version)}"
-            if self.env.is_conda and not self.env.enable_apple_silicon:
+            if self.env.is_conda:
                 if pkg.startswith("tensorflow-gpu"):
                     # From TF 2.4 onwards, Anaconda Tensorflow becomes a mess. The version of 2.5
                     # installed by Anaconda is compiled against an incorrect numpy version which


### PR DESCRIPTION
Ran some tests and fixed these issues:
- Tries and fails to install pynvx, moved to Nvidia requirement
- tensorflow-deps was missing
- Tries and fails to install tensorflow-deps / libblas using pip, now using Conda
- Wrong tensorflow-metal version
- The command for creating the Conda env wasn't working for me for some reason