### PR TITLE
update pipeline to trigger on pull_request, not trigger on non-code changes, add caching while installing dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,11 @@
-name: Python package
+name: ci/gh-actions/pytest
 
-on: [push]
+on:
+  push:
+  pull_request:
+    paths-ignore: 
+      - docs/**
+      - "**/README.md"
 
 jobs:
   build:
@@ -21,10 +26,12 @@ jobs:
             backend: amd
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}      
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: './requirements/requirements_${{ matrix.backend }}.txt'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This PR updates the GitHub Actions Pipeline to:

1. Trigger on both `push` and `pull_request`
2. Not trigger when making non-code changes (updating `docs` or `README.md`)
3. Adds a caching step to speed up install python dependencies 