### PR TITLE
Fix info description of color augmentation group

### DIFF
--- a/plugins/train/trainer/original_defaults.py
+++ b/plugins/train/trainer/original_defaults.py
@@ -88,7 +88,7 @@ _DEFAULTS = dict(
     color_lightness=dict(
         default=30,
         info="Percentage amount to randomly alter the lightness of each training image.\n"
-             "NB: This is ignored if the 'no-flip' option is enabled",
+             "NB: This is ignored if the 'no-augment-color' option is enabled",
         datatype=int,
         rounding=1,
         min_max=(0, 75),
@@ -96,7 +96,7 @@ _DEFAULTS = dict(
     color_ab=dict(
         default=8,
         info="Percentage amount to randomly alter the 'a' and 'b' colors of the L*a*b* color "
-             "space of each training image.\nNB: This is ignored if the 'no-flip' option is "
+             "space of each training image.\nNB: This is ignored if the 'no-augment-color' option is "
              "enabled",
         datatype=int,
         rounding=1,


### PR DESCRIPTION
Fix wrong description tooltips in configuration settings window in Trainer/ Original/ Color Augmentation section