### PR TITLE
add max scale option

### DIFF
--- a/lib/align/aligned_face.py
+++ b/lib/align/aligned_face.py
@@ -421,6 +421,21 @@ class AlignedFace():
         return self._cache.original_roi[0]
 
     @property
+    def original_roi_2(self) -> np.ndarray:
+        """ :class:`numpy.ndarray`: The location of the extracted face box within the original
+        frame. """
+        with self._cache.lock("original_roi"):
+            if self._cache.original_roi is None:
+                roi = np.array([[0, 0],
+                                [0, self._size - 1],
+                                [self._size - 1, self._size - 1],
+                                [self._size - 1, 0]])
+                roi = np.rint(self.transform_points(roi, invert=True)).astype("int32")
+                logger.trace("original roi: %s", roi)  # type: ignore
+                self._cache.original_roi = roi
+        return self._cache.original_roi
+        
+    @property
     def landmarks(self) -> np.ndarray:
         """ :class:`numpy.ndarray`: The 68 point facial landmarks aligned to the extracted face
         box. """

--- a/lib/align/detected_face.py
+++ b/lib/align/detected_face.py
@@ -134,6 +134,13 @@ class DetectedFace():
         """int: Bottom point (in pixels) of face detection bounding box within the parent image """
         assert self.top is not None and self.height is not None
         return self.top + self.height
+    
+    def scale_face(self, scale) -> None:
+        self.left = int(self.left * scale)
+        self.width = int(self.width * scale)
+        self.top = int(self.top * scale)
+        self.height = int(self.height * scale)
+        self._landmarks_xy *= scale
 
     def add_mask(self,
                  name: str,

--- a/lib/cli/args.py
+++ b/lib/cli/args.py
@@ -778,6 +778,16 @@ class ConvertArgs(ExtractConvertArgs):
                    "will be discarded unless '-k' (--keep-unchanged) is selected. NB: If you are "
                    "converting from images, then the filenames must end with the frame-number!")))
         argument_list.append(dict(
+            opts=("-ms", "--max-scale"),
+            action=Slider,
+            min_max=(0.0, 5.0),
+            rounding=1,
+            type=float,
+            dest=("max_scale"),
+            default=0.0,
+            group=_("Frame Processing"),
+            help=_("Max scale of converted face relative to model output size. Resizes frame to match dest face size. Set to 0 to keep frames unchanged.")))
+        argument_list.append(dict(
             opts=("-a", "--input-aligned-dir"),
             action=DirFullPaths,
             dest="input_aligned_dir",

--- a/plugins/extract/pipeline.py
+++ b/plugins/extract/pipeline.py
@@ -811,6 +811,24 @@ class ExtractMedia():
         logger.trace("Reapplying image: (filename: `%s`, image shape: %s)",  # type: ignore
                      self._filename, image.shape)
         self._image = image
+    
+    def scale_image(self, scale):
+        """ Scale :attr:`image`
+
+        Required for conversion with max scale.
+
+        Parameters
+        ----------
+        scale: float
+            The scale to be applied to :attr:`image`
+        """
+        interp = cv2.INTER_CUBIC if scale > 1 else cv2.INTER_AREA
+        dims = (round((self.image_shape[1] / 2 * scale) * 2),
+                round((self.image_shape[0] / 2 * scale) * 2))
+        self._image = cv2.resize(self._image, dims, interpolation=interp)
+        self._image_shape = cast(Tuple[int, int, int],self._image.shape)
+        for face in self._detected_faces:
+            face.scale_face(scale)
 
     def _image_as_bgr(self) -> "np.ndarray":
         """ Get a copy of the source frame in BGR format.

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -108,6 +108,8 @@ class Convert():  # pylint:disable=too-few-public-methods
         self._converter = Converter(self._predictor.output_size,
                                     self._predictor.coverage_ratio,
                                     self._predictor.centering,
+                                    self._predictor.max_scale,
+                                    self._images.is_video,
                                     self._disk_io.draw_transparent,
                                     self._disk_io.pre_encode,
                                     arguments,
@@ -729,6 +731,7 @@ class Predict():
         self._sizes = self._get_io_sizes()
         self._coverage_ratio = self._model.coverage_ratio
         self._centering = self._model.config["centering"]
+        self._max_scale = self._args.max_scale
 
         self._thread = self._launch_predictor()
         logger.debug("Initialized %s: (out_queue: %s)", self.__class__.__name__, self._out_queue)
@@ -768,6 +771,11 @@ class Predict():
     def centering(self) -> "CenteringType":
         """ str: The centering that the model was trained on (`"head", "face"` or `"legacy"`) """
         return self._centering
+    
+    @property
+    def max_scale(self) -> float:
+        """ float: The max scale of dest face to model output. """
+        return self._max_scale
 
     @property
     def has_predicted_mask(self) -> bool:


### PR DESCRIPTION
This PR adds the option to set a max scale parameter in conversion. Max scale is defined at the maximum ratio of the longest edge of any face's original_roi in the source frame to the model output size.

Example 1: Let max scale be 2 and model have a 256px output size. Image contains a face that is 768x400 px. Max ratio = 768/256 = 3. Therefore, the image will be scaled by 2/3 before pasting the predicted face.

Example 2: Let max scale be 1.5 and model have a 512px output size. Image contains a face that is 400x300 px. Max ratio = 400/512 < 1. Therefore, the image will not be scaled.

Example 3: Let max scale be 0 (default). The image will not be scaled.

Setting max_scale to a number less than 2 produces results that are far more realistic visually when the model resolution is small relative to dest.

This feature checks if the input is a folder of images, not a video, before applying the appropriate transformations. Video frames will need (trivial) further work to be compatible with variable resolution frames. However, it does not make sense to generate a video from different resolution frames. Therefore, this feature was not included.