### PR TITLE
Fixed dtype error when mixed precision was off

### DIFF
--- a/plugins/train/model/_base/settings.py
+++ b/plugins/train/model/_base/settings.py
@@ -617,7 +617,7 @@ class Settings():
                 retval.extend(self._get_mixed_precision_layers(config["layers"]))
                 continue
 
-            dtype = config["dtype"]
+            dtype = config.get("dtype", None)
             if isinstance(dtype, dict) and dtype["config"]["name"] == "mixed_float16":
                 logger.debug("Adding supported mixed precision layer: %s %s", layer["name"], dtype)
                 retval.append(layer["name"])


### PR DESCRIPTION
When you first try to run a model with some types of layers (such as a modified Phaze-A) without enabling mixed precision, the model can fail to train because the layer wasn't assigned a dtype.  To prevent a crash when this happens, we've switched the the config.get function to make sure we get a valid response if no dtype was set.