### PR TITLE
[FIX] Dockerfile.cpu: Update to Ubuntu 24.04 and optimize image size

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,19 +1,20 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # To disable tzdata and others from asking for input
-ENV DEBIAN_FRONTEND noninteractive
-ENV FACESWAP_BACKEND cpu
+ENV DEBIAN_FRONTEND=noninteractive
+ENV FACESWAP_BACKEND=cpu
 
-RUN apt-get update -qq -y
-RUN apt-get upgrade -y
-RUN apt-get install -y libgl1 libglib2.0-0 python3 python3-pip python3-tk git
+RUN apt-get update -qq -y && \
+    apt-get upgrade -y && \
+    apt-get install -y libgl1 libglib2.0-0 python3 python3-pip python3-tk git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN ln -s $(which python3) /usr/local/bin/python
 
 RUN git clone --depth 1 --no-single-branch https://github.com/deepfakes/faceswap.git
 WORKDIR "/faceswap"
 
-RUN python -m pip install --upgrade pip
-RUN python -m pip --no-cache-dir install -r ./requirements/requirements_cpu.txt
+RUN python -m pip --no-cache-dir install -r ./requirements/requirements_cpu.txt --break-system-packages
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
# Problem

<img width="828" height="500" alt="Screenshot 2026-01-22 at 19 34 05" src="https://github.com/user-attachments/assets/40f10dac-d16d-41ff-91d6-1d05a7c75dc2" />

## Summary

- Upgrade base image from Ubuntu 22.04 to 24.04
- Use modern ENV syntax (`VAR=value`)
- Consolidate apt-get commands into single RUN layer
- Add `apt-get clean` and remove lists to reduce image size
- Add `--break-system-packages` flag for PEP 668 compliance (required in Ubuntu 24.04)

## Motivation

Current Dockerfile.cpu has issues:

1. **ENV syntax warnings** during build (lines 4 and 5)
2. **Python 3.10 unsupported** - Ubuntu 22.04 ships Python 3.10, but faceswap requires 3.11+

Ubuntu 24.04 ships with Python 3.12, fixing both issues.