### PR TITLE
fix: correct typos throughout codebase

### DIFF
--- a/lib/gpu_stats/apple_silicon.py
+++ b/lib/gpu_stats/apple_silicon.py
@@ -92,7 +92,7 @@ class AppleSiliconStats(_GPUStats):
             self._log("debug",
                       f"Torch initialization test: (mem_info: {meminfo})")
         except RuntimeError as err:
-            msg = ("An unhandled exception occured initializing the device via Torch "
+            msg = ("An unhandled exception occurred initializing the device via Torch "
                    f"Library. Original error: {str(err)}")
             raise FaceswapError(msg) from err
 

--- a/lib/gpu_stats/nvidia.py
+++ b/lib/gpu_stats/nvidia.py
@@ -54,7 +54,7 @@ class NvidiaStats(_GPUStats):
                    f"Error: {str(err)}")
             raise FaceswapError(msg) from err
         except Exception as err:  # pylint:disable=broad-except
-            msg = ("An unhandled exception occured reading from the Nvidia Machine Learning "
+            msg = ("An unhandled exception occurred reading from the Nvidia Machine Learning "
                    f"Library. Original error: {str(err)}")
             raise FaceswapError(msg) from err
 

--- a/lib/gui/command.py
+++ b/lib/gui/command.py
@@ -146,10 +146,10 @@ class CommandTab(ttk.Frame):  # pylint:disable=too-many-ancestors
 
     def add_frame_separator(self):
         """ Add a separator between top and bottom frames """
-        logger.debug("Add frame seperator")
+        logger.debug("Add frame separator")
         sep = ttk.Frame(self, height=2, relief=tk.RIDGE)
         sep.pack(fill=tk.X, pady=(5, 0), side=tk.TOP)
-        logger.debug("Added frame seperator")
+        logger.debug("Added frame separator")
 
 
 class ActionFrame(ttk.Frame):  # pylint:disable=too-many-ancestors

--- a/lib/gui/display_page.py
+++ b/lib/gui/display_page.py
@@ -92,7 +92,7 @@ class DisplayPage(ttk.Frame):  # pylint:disable=too-many-ancestors
 
     def add_frame_separator(self):
         """ Add a separator between top and bottom frames """
-        logger.debug("Adding frame seperator")
+        logger.debug("Adding frame separator")
         sep = ttk.Frame(self, height=2, relief=tk.RIDGE)
         sep.pack(fill=tk.X, pady=(5, 0), side=tk.BOTTOM)
 

--- a/lib/system/sysinfo.py
+++ b/lib/system/sysinfo.py
@@ -239,7 +239,7 @@ def get_sysinfo() -> str:
     try:
         retval = _SysInfo().full_info()
     except Exception as err:  # pylint:disable=broad-except
-        retval = f"Exception occured trying to retrieve sysinfo: {str(err)}"
+        retval = f"Exception occurred trying to retrieve sysinfo: {str(err)}"
         raise
     return retval
 

--- a/plugins/extract/align/_base/aligner.py
+++ b/plugins/extract/align/_base/aligner.py
@@ -194,7 +194,7 @@ class Aligner(Extractor):  # pylint:disable=abstract-method
     def _handle_realigns(self, queue: Queue) -> tuple[bool, AlignerBatch] | None:
         """ Handle any items waiting for a second pass through the aligner.
 
-        If EOF has been recieved and items are still being processed through the first pass
+        If EOF has been received and items are still being processed through the first pass
         then wait for a short time and try again to collect them.
 
         On EOF return exhausted flag with an empty batch

--- a/tools/preview/control_panels.py
+++ b/tools/preview/control_panels.py
@@ -619,10 +619,10 @@ class ConfigFrame(ttk.Frame):  # pylint:disable=too-many-ancestors
 
     def _add_frame_separator(self) -> None:
         """Add a separator between top and bottom frames."""
-        logger.debug("Add frame seperator")
+        logger.debug("Add frame separator")
         sep = ttk.Frame(self._action_frame, height=2, relief=tk.RIDGE)
         sep.pack(fill=tk.X, pady=5, side=tk.TOP)
-        logger.debug("Added frame seperator")
+        logger.debug("Added frame separator")
 
     def _add_actions(self, parent: OptionsBook, config_key: str) -> None:
         """Add Action Buttons.


### PR DESCRIPTION
Fixes minor spelling errors:

- `seperator` → `separator` (5 instances)
- `recieved` → `received` (1 instance)
- `occured` → `occurred` (3 instances)

Found in logging messages and docstrings across 7 files.