### PR TITLE
bugfix: loss-function correctness and GUI/event-reader robustness

### DIFF
--- a/lib/model/losses/loss.py
+++ b/lib/model/losses/loss.py
@@ -86,7 +86,7 @@ class FocalFrequencyLoss(nn.Module):
                 row_to = (i + 1) * patch_rows
                 col_from = j * patch_cols
                 col_to = (j + 1) * patch_cols
-                patch_list.append(inputs[:, row_from: row_to, col_from:col_to, :])
+                patch_list.append(inputs[:, :, row_from:row_to, col_from:col_to])
 
         retval = torch.stack(patch_list, dim=1)
         return retval
@@ -314,37 +314,37 @@ class GradientLoss(nn.Module):
         top = img[:, 1:2, 1:2, :] + img[:, 0:1, 0:1, :]
         inner = img[:, 2:, 1:2, :] + img[:, :-2, 0:1, :]
         bottom = img[:, -1:, 1:2, :] + img[:, -2:-1, 0:1, :]
-        xy_left = torch.concatenate([top, inner, bottom], dim=1)
+        xy1_left = torch.concatenate([top, inner, bottom], dim=1)
         # Mid
         top = img[:, 1:2, 2:, :] + img[:, 0:1, :-2, :]
         mid = img[:, 2:, 2:, :] + img[:, :-2, :-2, :]
         bottom = img[:, -1:, 2:, :] + img[:, -2:-1, :-2, :]
-        xy_mid = torch.concatenate([top, mid, bottom], dim=1)
+        xy1_mid = torch.concatenate([top, mid, bottom], dim=1)
         # Right
         top = img[:, 1:2, -1:, :] + img[:, 0:1, -2:-1, :]
         inner = img[:, 2:, -1:, :] + img[:, :-2, -2:-1, :]
         bottom = img[:, -1:, -1:, :] + img[:, -2:-1, -2:-1, :]
-        xy_right = torch.concatenate([top, inner, bottom], dim=1)
+        xy1_right = torch.concatenate([top, inner, bottom], dim=1)
 
         # X_out2
         # Left
         top = img[:, 0:1, 1:2, :] + img[:, 1:2, 0:1, :]
         inner = img[:, :-2, 1:2, :] + img[:, 2:, 0:1, :]
         bottom = img[:, -2:-1, 1:2, :] + img[:, -1:, 0:1, :]
-        xy_left = torch.concatenate([top, inner, bottom], dim=1)
+        xy2_left = torch.concatenate([top, inner, bottom], dim=1)
         # Mid
         top = img[:, 0:1, 2:, :] + img[:, 1:2, :-2, :]
         mid = img[:, :-2, 2:, :] + img[:, 2:, :-2, :]
         bottom = img[:, -2:-1, 2:, :] + img[:, -1:, :-2, :]
-        xy_mid = torch.concatenate([top, mid, bottom], dim=1)
+        xy2_mid = torch.concatenate([top, mid, bottom], dim=1)
         # Right
         top = img[:, 0:1, -1:, :] + img[:, 1:2, -2:-1, :]
         inner = img[:, :-2, -1:, :] + img[:, 2:, -2:-1, :]
         bottom = img[:, -2:-1, -1:, :] + img[:, -1:, -2:-1, :]
-        xy_right = torch.concatenate([top, inner, bottom], dim=1)
+        xy2_right = torch.concatenate([top, inner, bottom], dim=1)
 
-        xy_out1 = torch.concatenate([xy_left, xy_mid, xy_right], dim=2)
-        xy_out2 = torch.concatenate([xy_left, xy_mid, xy_right], dim=2)
+        xy_out1 = torch.concatenate([xy1_left, xy1_mid, xy1_right], dim=2)
+        xy_out2 = torch.concatenate([xy2_left, xy2_mid, xy2_right], dim=2)
         return (xy_out1 - xy_out2) * 0.25
 
     def forward(self, y_true: torch.Tensor, y_pred: torch.Tensor) -> torch.Tensor:

--- a/lib/model/losses/perceptual_loss.py
+++ b/lib/model/losses/perceptual_loss.py
@@ -242,7 +242,7 @@ class GMSDLoss(nn.Module):
             out = out.reshape(bs, height, width, channels, 2)
             gx = out[..., 0]
             gy = out[..., 1]
-            out = torch.atan(gx / gy)
+            out = torch.atan2(gx, gy)
         # magnitude of edges -- unified x & y edges don't work well with Neural Networks
         return out
 
@@ -333,6 +333,8 @@ class LDRFLIPLoss(nn.Module):  # pylint:disable=too-many-instance-attributes
         ``True`` to output the loss function as a HxWx1 image output. ``False`` to reduce to mean
         for each item in the batch. Default: ``False``
     """
+    _c_max: torch.Tensor
+
     def __init__(self,
                  computed_distance_exponent: float = 0.7,
                  feature_exponent: float = 0.5,
@@ -359,6 +361,14 @@ class LDRFLIPLoss(nn.Module):  # pylint:disable=too-many-instance-attributes
         self._feature_detector = _FeatureDetection(pixels_per_degree)
         self._rgb2lab = ColorSpaceConvert(from_space="rgb", to_space="lab")
         self._rgb2ycxcz = ColorSpaceConvert("srgb", "ycxcz")
+
+        hunt_adjusted_green = self._hunt_adjustment(
+            self._rgb2lab(torch.Tensor([[[[0.0]], [[1.0]], [[0.0]]]]).float()))
+        hunt_adjusted_blue = self._hunt_adjustment(
+            self._rgb2lab(torch.Tensor([[[[0.0]], [[0.0]], [[1.0]]]]).float()))
+        self.register_buffer(
+            "_c_max",
+            self._hyab(hunt_adjusted_green, hunt_adjusted_blue) ** computed_distance_exponent)
 
     @classmethod
     def _hunt_adjustment(cls, image: torch.Tensor) -> torch.Tensor:
@@ -437,18 +447,10 @@ class LDRFLIPLoss(nn.Module):  # pylint:disable=too-many-instance-attributes
 
         preprocessed_true = self._hunt_adjustment(self._rgb2lab(filtered_true))
         preprocessed_pred = self._hunt_adjustment(self._rgb2lab(filtered_pred))
-        hunt_adjusted_green = self._hunt_adjustment(
-            self._rgb2lab(torch.Tensor([[[[0.0]], [[1.0]], [[0.0]]]]).float().to(y_pred.device))
-            )
-        hunt_adjusted_blue = self._hunt_adjustment(
-            self._rgb2lab(torch.Tensor([[[[0.0]], [[0.0]], [[1.0]]]]).float().to(y_pred.device))
-            )
 
         delta = self._hyab(preprocessed_true, preprocessed_pred)
         power_delta = delta ** self._computed_distance_exponent
-        c_max = self._hyab(hunt_adjusted_green,
-                           hunt_adjusted_blue) ** self._computed_distance_exponent
-        return self._redistribute_errors(power_delta, c_max)
+        return self._redistribute_errors(power_delta, self._c_max)
 
     def _process_features(self, y_true: torch.Tensor, y_pred: torch.Tensor) -> torch.Tensor:
         """Perform the color processing part of the FLIP loss function
@@ -788,7 +790,7 @@ class MSSIMLoss(nn.Module):
         The gaussian kernel in channels first depthwise format (C,1,H,W)
         """
         coords = torch.arange(0, size, dtype=torch.float32, device=self._divisor_tensor.device)
-        coords -= size - 1 / 2.
+        coords -= (size - 1) / 2.
 
         gauss = coords ** 2 * (-0.5 / self._filter_sigma_sq)
 

--- a/lib/training/preview_tk.py
+++ b/lib/training/preview_tk.py
@@ -236,11 +236,17 @@ class _Taskbar():
             return
 
         for widget in reversed(self._gui_mapped):
-            if widget.winfo_ismapped():
-                logger.debug("Removing widget: %s", widget)
-                widget.pack_forget()
-                widget.destroy()
-                del widget
+            try:
+                if not widget.winfo_exists():
+                    continue
+                if widget.winfo_ismapped():
+                    logger.debug("Removing widget: %s", widget)
+                    widget.pack_forget()
+                    widget.destroy()
+            except tk.TclError:
+                # Widget was already torn down by its parent
+                continue
+        self._gui_mapped.clear()
 
         for var in list(self._vars):
             logger.debug("Deleting tk variable: %s", var)

--- a/lib/training/tensorboard.py
+++ b/lib/training/tensorboard.py
@@ -61,6 +61,11 @@ class RecordIterator:
         logger.trace("EOF. Closing '%s'", self._file_path)  # type:ignore[attr-defined]
         self._log_file.close()
 
+    # Sanity cap for a single TFRecord. Tensorboard event records are tiny in practice (KB-scale);
+    # anything larger means we caught a partial write from a live writer and the length bytes are
+    # garbage.
+    _MAX_RECORD_SIZE = 1 << 30  # 1 GiB
+
     def __next__(self) -> bytes:
         """ Get the next event log from a Tensorboard event file
 
@@ -76,17 +81,33 @@ class RecordIterator:
         """
         self._on_file_read()
 
-        b_header = self._log_file.read(8)
+        record_start = self._log_file.tell()
 
-        if not b_header:
+        b_header = self._log_file.read(8)
+        if len(b_header) < 8:
+            # Partial header (live writer in progress, or true EOF). Rewind so the next call
+            # picks up at the same position once the writer has flushed more bytes.
+            self._log_file.seek(record_start, 0)
             self._on_file_end()
             raise StopIteration
 
         read_len = int(struct.unpack('Q', b_header)[0])
-        self._log_file.seek(4, 1)
-        data = self._log_file.read(read_len)
+        if read_len > self._MAX_RECORD_SIZE:
+            logger.warning("Implausible record length %s in '%s' at offset %s; treating as "
+                           "partial write and stopping.", read_len, self._file_path, record_start)
+            self._log_file.seek(record_start, 0)
+            self._on_file_end()
+            raise StopIteration
 
-        self._log_file.seek(4, 1)
+        len_crc = self._log_file.read(4)
+        data = self._log_file.read(read_len)
+        data_crc = self._log_file.read(4)
+        if len(len_crc) < 4 or len(data) < read_len or len(data_crc) < 4:
+            # Partial record body — rewind and try again later.
+            self._log_file.seek(record_start, 0)
+            self._on_file_end()
+            raise StopIteration
+
         logger.trace("Returning event data of len %s", read_len)  # type:ignore[attr-defined]
 
         return data


### PR DESCRIPTION
## Summary

Two unrelated clusters of bugs uncovered while reviewing the recent torch-loss-functions-in-Keras work and trying to use the GUI training preview/analysis tabs.

### Loss-function correctness (`lib/model/losses/`)

- **`GradientLoss._diff_xy`** — variable-name collision. The two halves of the mixed second-order term (` # x_out1 ` and ` # X_out2 `) both wrote into `xy_left` / `xy_mid` / `xy_right`, so by the time `xy_out1` and `xy_out2` were assembled they pointed at the *same* tensors and the final `(xy_out1 - xy_out2) * 0.25` was identically zero. The cross-derivative term in `GradientLoss` has therefore been silently dead for as long as this code has existed. Renamed to `xy1_*` / `xy2_*`.
- **`MSSIMLoss._fspecial_gauss`** — operator-precedence bug. `coords -= size - 1 / 2.` parses as `coords -= size - 0.5`, so for `size=11` the kernel coordinates land at `[-10.5 … -0.5]` instead of the centred `[-5 … 5]`. The companion `DSSIMObjective._get_kernel` already had the correct `(self._filter_size - 1) / 2.`. Added the missing parens.
- **`FocalFrequencyLoss._get_patches`** — was still slicing with NHWC indices (`inputs[:, row_from:row_to, col_from:col_to, :]`) after the `permute(0, 3, 1, 2)` to NCHW. Worked by accident for the default `patch_factor=1` on square images; for `patch_factor > 1` the FFT was being run over the wrong axes. Now slices the H/W axes directly.
- **`LDRFLIPLoss._color_pipeline`** — the hunt-adjusted RGB reference colours and the resulting `c_max` are constants, but were rebuilt on every forward pass. Compute `c_max` once in `__init__` and register it as a buffer so it follows the module across `.to(device)`.
- **`GMSDLoss._map_scharr_edges`** — `torch.atan(gx / gy)` divides by zero wherever `gy == 0`. Switched to `torch.atan2(gx, gy)`. The branch is only reachable when `magnitude=False` (not currently exercised by `forward`), so this is a latent fix.

### GUI / event-reader robustness

- **`_Taskbar.destroy_widgets` (`lib/training/preview_tk.py`)** — `widget.winfo_ismapped()` raised `TclError: bad window path name` when the parent (e.g. the Notebook tab) had already torn the widget down before `destroy_widgets` ran. Wrapped in a `winfo_exists()` guard and a `try/except tk.TclError`. Also `self._gui_mapped.clear()` after the loop — the previous `del widget` only dropped the loop variable, leaving stale references in the list, so a second invocation would walk over already-destroyed widgets.
- **`RecordIterator.__next__` (`lib/training/tensorboard.py`)** — when the GUI tailed an event file the trainer was still writing, it could catch a partial record: 8 bytes of length header flushed but the body not yet there. The garbage length (often `~10**18`) was then handed to `file.read()`, raising `OverflowError: cannot fit 'int' into an index-sized integer` or `MemoryError`, which killed the analysis thread. Now records the start offset, reads the full record (header + len-CRC + data + data-CRC) atomically, and on any short read or implausible length (cap of 1 GiB) seeks back to the start so the next poll resumes once the writer has flushed.

## Behaviour-change notes for reviewers

- Models trained with `GradientLoss` were effectively running with the second-order term reduced to `_diff_xx + _diff_yy` (the mixed term contributed exactly zero). After this fix the loss surface changes; existing checkpoints still load fine but the gradients during continued training will differ.
- `MSSIMLoss` was running on a badly off-centre Gaussian. After this fix the loss values change significantly — same caveat for in-flight training.
- `FocalFrequencyLoss` users who only ever ran with `patch_factor=1` will see no behavioural change on square images.

## Test plan

- [ ] Unit test for `GradientLoss._diff_xy`: verify it now returns non-zero values for non-trivial inputs and matches the analytical mixed-derivative on a smooth synthetic image.
- [ ] Unit test for `MSSIMLoss._fspecial_gauss`: kernel sums to ~1 and is symmetric around the centre.
- [ ] Unit test for `FocalFrequencyLoss` with `patch_factor=2,4` on a non-square-friendly batch shape.
- [ ] Confirm `LDRFLIPLoss` still produces the same `c_max` value before/after (regression check; not a behaviour change).
- [ ] Manual: run training with the GUI, trigger a preview-tab close while training is live (taskbar destroy path) and watch the analysis tab refresh while the writer is still flushing (event reader path) — both should no longer surface tracebacks in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)