### PR TITLE
fix(gui): propagate --logfile to processes launched from the GUI

### DIFF
--- a/lib/gui/wrapper.py
+++ b/lib/gui/wrapper.py
@@ -28,10 +28,17 @@ logger = logging.getLogger(__name__)
 
 class ProcessWrapper():
     """ Builds command, launches and terminates the underlying
-        faceswap process. Updates GUI display depending on state """
+        faceswap process. Updates GUI display depending on state
 
-    def __init__(self) -> None:
+    Parameters
+    ----------
+    logfile : str | None
+        The GUI startup logfile to pass to child commands. ``None`` to use their default logfile
+    """
+
+    def __init__(self, logfile: str | None = None) -> None:
         logger.debug("Initializing %s", self.__class__.__name__)
+        self._logfile = logfile
         self._tk_vars = get_config().tk_vars
         self._set_callbacks()
         self._command: str | None = None
@@ -164,11 +171,15 @@ class ProcessWrapper():
         args.extend([pathexecscript, command])
 
         cli_opts = get_config().cli_opts
+        has_logfile = False
         for cliopt in cli_opts.gen_cli_arguments(command):
             args.extend(cliopt)
+            has_logfile |= cliopt[0] in ("-F", "--logfile")
             if command == "train" and not generate:
                 self._get_training_session_info(cliopt)
 
+        if self._logfile and not has_logfile:
+            args.extend(("-F", self._logfile))
         if not generate:
             args.append("-G")  # Indicate to Faceswap that we are running the GUI
         if generate:

--- a/lib/logger.py
+++ b/lib/logger.py
@@ -435,6 +435,9 @@ def _file_handler(loglevel,
     """
     if log_file:
         filename = log_file
+        if command == "gui":
+            stem, extension = os.path.splitext(filename)
+            filename = f"{stem}_gui{extension}"
     else:
         filename = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "faceswap")
         # Windows has issues sharing the log file with sub-processes, so log GUI separately

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -25,9 +25,12 @@ class FaceswapGui(tk.Tk):
         Output to the terminal rather than to Faceswap's internal console
     config_file : str | None
         Path to a custom .ini configuration file. ``None`` to use the default config file
+    logfile : str | None
+        Path to the logfile used by commands launched from the GUI. ``None`` to use the default
+        logfile
     """
 
-    def __init__(self, debug, config_file):
+    def __init__(self, debug, config_file, logfile):
         logger.debug("Initializing %s", self.__class__.__name__)
         super().__init__()
         cfg.load_config(config_file)
@@ -37,7 +40,7 @@ class FaceswapGui(tk.Tk):
         self.set_fonts()
         self._config.set_geometry(1200, 640, cfg.fullscreen())
 
-        self.wrapper = ProcessWrapper()
+        self.wrapper = ProcessWrapper(logfile)
         self.objects = {}
 
         get_images().delete_preview()
@@ -186,7 +189,7 @@ class FaceswapGui(tk.Tk):
 class Gui():
     """ The GUI process. """
     def __init__(self, arguments):
-        self.root = FaceswapGui(arguments.debug, arguments.config_file)
+        self.root = FaceswapGui(arguments.debug, arguments.config_file, arguments.logfile)
 
     def process(self):
         """ Builds the GUI """


### PR DESCRIPTION
Running the GUI with `-F/--logfile` only redirected the GUI's own log; the extract/train/convert processes it launched still wrote to their default logfile, so the flag looked like it did nothing. Closes #1377.

## Updates

- `scripts/gui.py`: `FaceswapGui` and `Gui` now take `arguments.logfile` and pass it through to `ProcessWrapper`.
- `lib/gui/wrapper.py`: `ProcessWrapper` accepts the logfile and appends `-F <logfile>` to each generated child command, but only when the user has not already set `-F/--logfile` for that command in the GUI, so an explicit per-command setting still wins.
- `lib/logger.py`: when an explicit `log_file` is given and the command is `gui`, the GUI's own handler writes to `<stem>_gui<ext>`. The parent and its children would otherwise share one file, which is the Windows sub-process sharing problem the default path already avoids with a separate GUI log.

Net effect: `python faceswap.py gui -F /path/run.log` puts the GUI in `/path/run_gui.log` and the jobs it launches in `/path/run.log`.

Tested by compiling the three touched modules and by reading the arg-generation path in `gen_cli_arguments`; I did not have a working GUI session here, so a quick sanity run on your side would be worth it. The `_gui` suffix is the one debatable bit: it keeps parity with the existing default behaviour, but if you would rather both go to the same file, that hunk drops cleanly on its own.
